### PR TITLE
Python 3.5 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - 2.7
   - 3.4
+  - 3.5
 
 install:
   # Install miniconda
@@ -25,12 +26,12 @@ install:
   - conda create --quiet -n $ENV_NAME python=$TRAVIS_PYTHON_VERSION
   - source activate $ENV_NAME
 
-  # Customise the testing environment
-  # ---------------------------------
+  # Customise the testing environment.
+  # ----------------------------------
   - conda config --add channels scitools
   - conda install --quiet --file conda-requirements.txt
 
-  # Output debug info
+  # Output debug info.
   - conda list
   - conda info -a
 

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -42,7 +42,7 @@ import netcdftime
 import numpy as np
 
 from . import config
-from .util import approx_equal
+from .util import _OrderedHashable, approx_equal
 
 __version__ = '0.1.1'
 
@@ -827,9 +827,6 @@ def is_vertical(unit):
 
     """
     return as_unit(unit).is_vertical()
-
-
-from .util import _OrderedHashable
 
 
 class Unit(_OrderedHashable):

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -3,6 +3,6 @@ six
 netcdf4
 udunits=2.*
 
-# Testing/documentation dependencies.
+# Testing.
 pytest
-pep8=1.5.7
+pep8


### PR DESCRIPTION
We need to `pip install pep8==1.5.7` because that version does not exist on conda+python35.
