### PR TITLE
Bump version

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -44,7 +44,7 @@ import numpy as np
 from . import config
 from .util import _OrderedHashable, approx_equal
 
-__version__ = '0.2.0'
+__version__ = '1.0.0'
 
 __all__ = ['CALENDAR_STANDARD',
            'CALENDAR_GREGORIAN',

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -44,7 +44,7 @@ import numpy as np
 from . import config
 from .util import _OrderedHashable, approx_equal
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 
 __all__ = ['CALENDAR_STANDARD',
            'CALENDAR_GREGORIAN',


### PR DESCRIPTION
Given the [comment](https://github.com/SciTools/cf_units/pull/36#issuecomment-153313070) and follow-on discussion on #36, I think it is now time for a new release of `cf_units`.

What do people think? Bump version to v0.2 as proposed here, or go as far as v0.5? Thoughts welcome.
