### PR TITLE
Added "inplace" keyword argument to "Unit.convert"

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1849,7 +1849,7 @@ class Unit(_OrderedHashable):
         """
         return not self == other
 
-    def convert(self, value, other, ctype=FLOAT64, inplace=True):
+    def convert(self, value, other, ctype=FLOAT64, inplace=False):
         """
         Converts a single ``value`` or NumPy array of ``value``s from the
         current unit to the other target unit.
@@ -1868,8 +1868,9 @@ class Unit(_OrderedHashable):
             when `value` is not a NumPy array or is a NumPy array composed of
             NumPy integers. The default is 64-bit double-precision conversion.
         * inplace (bool):
-            If ``True``, convert the values in-place. A new array will be
-            created if ``value`` is an integer NumPy array.
+            If ``False``, return a deep copy of the value array. If ``True``,
+            convert the values in-place. A new array will be created if
+            ``value`` is an integer NumPy array.
 
         Returns:
             float or numpy.ndarray of appropriate float type
@@ -1901,10 +1902,10 @@ class Unit(_OrderedHashable):
         if self == other:
             return value
 
-        if not inplace:
-            result = copy.deepcopy(value)
-        else:
+        if inplace:
             result = value
+        else:
+            result = copy.deepcopy(value)
 
         if self.is_convertible(other):
             # Use utime for converting reference times that are not using a

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1851,8 +1851,8 @@ class Unit(_OrderedHashable):
 
     def convert(self, value, other, ctype=FLOAT64, inplace=False):
         """
-        Converts a single ``value`` or NumPy array of ``value``s from the
-        current unit to the other target unit.
+        Converts a single value or NumPy array of values from the current unit
+        to the other target unit.
 
         If the units are not convertible, then no conversion will take place.
 
@@ -1873,7 +1873,7 @@ class Unit(_OrderedHashable):
             ``value`` is an integer NumPy array.
 
         Returns:
-            float or numpy.ndarray of appropriate float type
+            float or numpy.ndarray of appropriate float type.
 
         For example:
 
@@ -1885,17 +1885,17 @@ class Unit(_OrderedHashable):
             31.999999999999886
             >>> c.convert(0, f, cf_units.FLOAT32)
             32.0
-            >>> a64 = np.arange(10, dtype=np.float64)
+            >>> a64 = np.arange(3, dtype=np.float64)
             >>> c.convert(a64, f)
-            array([ 32. ,  33.8,  35.6,  37.4,  39.2,  41. ,  42.8,  44.6,
-                    46.4,  48.2])
-            >>> a32 = np.arange(10, dtype=np.float32)
+            array([ 32. ,  33.8,  35.6])
+            >>> a32 = np.arange(3, dtype=np.float32)
             >>> c.convert(a32, f)
-            array([ 32.        ,  33.79999924,  35.59999847,  37.40000153,
-                    39.20000076,  41.        ,  42.79999924,  44.59999847,
-                    46.40000153,  48.20000076], dtype=float32)
+            array([ 32.        ,  33.79999924,  35.59999847], dtype=float32)
 
-        .. note:: Conversion between unit calendars is not permitted.
+        .. note::
+
+           Conversion between unit calendars is not permitted.
+
         """
         other = as_unit(other)
 

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -892,16 +892,16 @@ class TestInPlace(unittest.TestCase):
 
         orig = np.arange(3, dtype=np.float32)
 
-        # Test inplace conversion alters the original array.
-        converted = c.convert(orig, f)
-        np.testing.assert_array_equal(orig, converted)
-        self.assertTrue(np.may_share_memory(orig, converted))
-
         # Test arrays are not equal without inplace conversions.
-        converted = c.convert(orig, f, inplace=False)
+        converted = c.convert(orig, f)
         with self.assertRaises(AssertionError):
             np.testing.assert_array_equal(orig, converted)
         self.assertFalse(np.may_share_memory(orig, converted))
+
+        # Test inplace conversion alters the original array.
+        converted = c.convert(orig, f, inplace=True)
+        np.testing.assert_array_equal(orig, converted)
+        self.assertTrue(np.may_share_memory(orig, converted))
 
 
 if __name__ == '__main__':

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -885,15 +885,23 @@ class TestImmutable(unittest.TestCase):
 class TestInPlace(unittest.TestCase):
 
     def test1(self):
-        # Check conversions do not change original object
+        """Test shared memory for conversion operations."""
+
         c = unit.Unit('deg_c')
         f = unit.Unit('deg_f')
 
         orig = np.arange(3, dtype=np.float32)
-        converted = c.convert(orig, f)
 
+        # Test inplace conversion alters the original array.
+        converted = c.convert(orig, f)
+        np.testing.assert_array_equal(orig, converted)
+        self.assertTrue(np.may_share_memory(orig, converted))
+
+        # Test arrays are not equal without inplace conversions.
+        converted = c.convert(orig, f, inplace=False)
         with self.assertRaises(AssertionError):
             np.testing.assert_array_equal(orig, converted)
+        self.assertFalse(np.may_share_memory(orig, converted))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Changed "convert" to in-place for float-to-float conversions.
- Revised "convert" docstring.
- Updated unit test.
