### PR TITLE
BUG: Fixed as_unit calendar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ cf\_units
 .. image:: https://api.travis-ci.org/SciTools/cf_units.png
    :target: http://travis-ci.org/SciTools/cf_units
 
-\(C) British Crown Copyright 2010 - 2015, Met Office
+\(C) British Crown Copyright 2015 - 2016, Met Office
 
 Units of measure as required by the Climate and Forecast (CF) metadata
 conventions.

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -863,14 +863,6 @@ class Unit(_OrderedHashable):
     def __hash__(self):
         return hash(self._identity())
 
-    def __eq__(self, other):
-        return (isinstance(other, type(self)) and
-                self._identity() == other._identity())
-
-    def __ne__(self, other):
-        # Since we've defined __eq__ we should also define __ne__.
-        return not self == other
-
     # Provide default ordering semantics
 
     def __lt__(self, other):

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2015 - 2016, Met Office
 #
 # This file is part of cf_units.
 #

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -781,6 +781,8 @@ def as_unit(unit):
         if use_cache:
             result = _CACHE.get(unit)
         if result is None:
+            # Typically unit is a string, however we cater for other types of
+            # 'unit' (e.g. iris.unit.Unit).
             result = Unit(unit, calendar=getattr(unit, 'calendar', None))
             if use_cache:
                 _CACHE[unit] = result

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -781,7 +781,7 @@ def as_unit(unit):
         if use_cache:
             result = _CACHE.get(unit)
         if result is None:
-            result = Unit(unit)
+            result = Unit(unit, calendar=getattr(unit, 'calendar', None))
             if use_cache:
                 _CACHE[unit] = result
     return result

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2015 - 2016, Met Office
 #
 # This file is part of cf_units.
 #

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -218,4 +218,4 @@ class Test_convert__masked_array(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    tests.main()
+    unittest.main()

--- a/cf_units/tests/unit/unit/test_as_unit.py
+++ b/cf_units/tests/unit/unit/test_as_unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2016, Met Office
 #
 # This file is part of cf_units.
 #
@@ -28,26 +28,15 @@ from cf_units import as_unit, Unit
 
 class StubUnit(object):
     def __init__(self, calendar=None):
-        self._calendar = str(calendar) if calendar is not None else None
+        self.calendar = str(calendar) if calendar is not None else None
+        # udunit category
+        self.category = 2
+        # ut_unit should be an integer but not under test
+        self.ut_unit = 0
+        self.origin = 'hours since 1970-01-01 00:00:00'
 
     def __str__(self):
         return self.origin
-
-    @property
-    def origin(self):
-        return 'hours since 1970-01-01 00:00:00'
-
-    @property
-    def ut_unit(self):
-        return 22943184
-
-    @property
-    def calendar(self):
-        return self._calendar
-
-    @property
-    def category(self):
-        return 2
 
 
 class TestAll(unittest.TestCase):

--- a/cf_units/tests/unit/unit/test_as_unit.py
+++ b/cf_units/tests/unit/unit/test_as_unit.py
@@ -22,8 +22,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import copy
 import unittest
 
-import mock
-
 import cf_units
 from cf_units import as_unit, Unit
 

--- a/cf_units/tests/unit/unit/test_as_unit.py
+++ b/cf_units/tests/unit/unit/test_as_unit.py
@@ -1,0 +1,87 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of cf_units.
+#
+# cf_units is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cf_units is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cf_units.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the `cf_units.as_unit` function."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+import copy
+import unittest
+
+import mock
+
+import cf_units
+from cf_units import as_unit, Unit
+
+
+class StubUnit(object):
+    def __init__(self, calendar=None):
+        self._calendar = str(calendar)
+
+    def __str__(self):
+        return self.origin
+
+    @property
+    def origin(self):
+        return 'hours since 1970-01-01 00:00:00'
+
+    @property
+    def ut_unit(self):
+        return 22943184
+
+    @property
+    def calendar(self):
+        return self._calendar
+
+    @property
+    def category(self):
+        return 2
+
+
+class TestAll(unittest.TestCase):
+    def _assert_unit_equal(self, unit1, unit2):
+        # Custom equality assertion of units since equality of the Unit class
+        # utilises as_unit.
+        for attribute in ['origin', 'calendar', 'category']:
+            self.assertEqual(getattr(unit1, attribute),
+                             getattr(unit2, attribute))
+
+    def test_cf_unit(self):
+        unit = Unit('hours since 1970-01-01 00:00:00', calendar='360_day')
+        target = copy.copy(unit)
+        result = as_unit(unit)
+
+        self._assert_unit_equal(result, target)
+        self.assertIs(result, unit)
+
+    def test_non_cf_unit_no_calendar(self):
+        # Check that as_unit returns a default calendar (Gregorian)
+        unit = StubUnit()
+        target = copy.copy(unit)
+        result = as_unit(unit)
+
+        self.assertEqual(result.calendar, 'gregorian')
+
+    def test_non_cf_unit_with_calendar(self):
+        unit = StubUnit('360_day')
+        target = copy.copy(unit)
+        result = as_unit(unit)
+        self._assert_unit_equal(result, target)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cf_units/tests/unit/unit/test_as_unit.py
+++ b/cf_units/tests/unit/unit/test_as_unit.py
@@ -30,7 +30,7 @@ from cf_units import as_unit, Unit
 
 class StubUnit(object):
     def __init__(self, calendar=None):
-        self._calendar = str(calendar)
+        self._calendar = str(calendar) if calendar is not None else None
 
     def __str__(self):
         return self.origin

--- a/cf_units/tests/unit/unit/test_as_unit.py
+++ b/cf_units/tests/unit/unit/test_as_unit.py
@@ -59,6 +59,8 @@ class TestAll(unittest.TestCase):
                              getattr(unit2, attribute))
 
     def test_cf_unit(self):
+        # Ensure that as_unit returns the same cf_unit.Unit object and
+        # remains unchanged.
         unit = Unit('hours since 1970-01-01 00:00:00', calendar='360_day')
         target = copy.copy(unit)
         result = as_unit(unit)
@@ -67,14 +69,20 @@ class TestAll(unittest.TestCase):
         self.assertIs(result, unit)
 
     def test_non_cf_unit_no_calendar(self):
-        # Check that as_unit returns a default calendar (Gregorian)
+        # On passing as_unit a cf_unit.Unit-like object (not a cf_unit.Unit
+        # object) with no calendar, ensure that a cf_unit.Unit is returned
+        # with default calendar (Gregorian).
         unit = StubUnit()
         target = copy.copy(unit)
         result = as_unit(unit)
 
         self.assertEqual(result.calendar, 'gregorian')
+        self.assertIsInstance(result, Unit)
 
     def test_non_cf_unit_with_calendar(self):
+        # On passing as_unit a cf_unit.Unit-like object (not a cf_unit.Unit
+        # object) with calendar, ensure that a cf_unit.Unit is returned
+        # with the same calendar specified in the original unit-like object.
         unit = StubUnit('360_day')
         target = copy.copy(unit)
         result = as_unit(unit)


### PR DESCRIPTION
See #47 for further context.
1. Passing a 'calendar' attribute when instantiating a `cf_unit.Unit` from a non `cf_unit.Unit` in `cf_unit.as_unit` (when available) to retain calendar information.  This in particular allows the supporting of `iris.unit.Unit` objects to be passed to `cf_unit.as_unit`.
2. Removed re-defined `__eq__` and `__ne__` special methods of Unit (two `__eq__` and `__ne__` special methods are currently present)..
