### PR TITLE
Use site config to specify UDUNITS2 XML database location

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -380,8 +380,10 @@ if not _ud_system:
         # relative to sys.prefix to support environments such as conda.
         _ud_system = _ut_read_xml(None)
         if _ud_system is None:
-            _alt_xml_path = os.path.join(sys.prefix, 'share',
-                                         'udunits', 'udunits2.xml')
+            _alt_xml_path = config.get_option(
+                'System', 'udunits2_xml_path',
+                default=os.path.join(sys.prefix, 'share', 'udunits',
+                                     'udunits2.xml'))
             _ud_system = _ut_read_xml(_alt_xml_path.encode())
     if not _ud_system:
         _status_msg = 'UNKNOWN'

--- a/cf_units/etc/site.cfg.template
+++ b/cf_units/etc/site.cfg.template
@@ -1,2 +1,3 @@
 [System]
 udunits2_path = /path/to/libudunits2.so
+udunits2_xml_path = /path/to/udunits2.xml


### PR DESCRIPTION
The location of the UDUNITS2 XML database changes between *nix and Win in conda-land. So, to get around this conda behaviour, I've set cf_units to pick up the location of the UDUNITS2 XML database from its `site.cfg` as it already does for the UDUNITS2 executable.

This is a sister change to the [conda-recipes change](https://github.com/SciTools/conda-recipes-scitools/pull/171) that added automatic setting of UDUNITS2 XML database location within `site.cfg` for conda installs of cf_units.
