### PR TITLE
Fix license headers and coding standards tests

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2016, Met Office
+# (C) British Crown Copyright 2015 - 2017, Met Office
 #
 # This file is part of cf_units.
 #

--- a/cf_units/tests/integration/__init__.py
+++ b/cf_units/tests/integration/__init__.py
@@ -1,0 +1,16 @@
+# (C) British Crown Copyright 2016 - 2017, Met Office
+#
+# This file is part of cf_units.
+#
+# cf_units is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cf_units is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cf_units.  If not, see <http://www.gnu.org/licenses/>.

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2015, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of cf_units.
 #

--- a/cf_units/tests/unit/__init__.py
+++ b/cf_units/tests/unit/__init__.py
@@ -1,20 +1,20 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
-# This file is part of Iris.
+# This file is part of cf_units.
 #
-# Iris is free software: you can redistribute it and/or modify it under
+# cf_units is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the
 # Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Iris is distributed in the hope that it will be useful,
+# cf_units is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for the :mod:`iris` package."""
+# along with cf_units.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the :mod:`cf_units` package."""
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,3 +1,20 @@
+# (C) British Crown Copyright 2016 - 2017, Met Office
+#
+# This file is part of cf_units.
+#
+# cf_units is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cf_units is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cf_units.  If not, see <http://www.gnu.org/licenses/>.
+
 # -*- coding: utf-8 -*-
 #
 # cf_units documentation build configuration file, created by


### PR DESCRIPTION
The license header tests are currently not being run because the code looks in the wrong directory to determine if it's being run in a git repo. This code fixes that, and updates the license headers which would now fail. Also adds some exclusions and fixes a Python 3 compatibility issue.

Edit: Forgot to mention that the pep8 tests were also looking for the wrong documentation directory. I've fixed that, but there are no files in there which need checking anyway.