### PR TITLE
Use self.symbol as consistent string representation

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1670,12 +1670,12 @@ class Unit(_OrderedHashable):
         For example:
 
             >>> import cf_units
-            >>> u = cf_units.Unit('meters')
+            >>> u = cf_units.Unit('kg meter2 second-3')
             >>> str(u)
-            'meters'
+            'W'
 
         """
-        return self.origin or self.name
+        return self.symbol
 
     def __repr__(self):
         """

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1670,12 +1670,12 @@ class Unit(_OrderedHashable):
         For example:
 
             >>> import cf_units
-            >>> u = cf_units.Unit('kg meter2 second-3')
+            >>> u = cf_units.Unit('miles/hour')
             >>> str(u)
-            'W'
+            'miles/hour'
 
         """
-        return self.symbol
+        return self.origin or self.symbol
 
     def __repr__(self):
         """


### PR DESCRIPTION
Currently, the string representation uses `self.origin` - the string used to create the instance. After an arithmetic operation, the returned instance does not have this attribute any more and uses `self.name`, which is most likely different from `self.origin`. `self.name` also spells out the base units which is very verbose.

I suggest using `self.symbol` as string representation:

```python
import cf_units

watt = cf_units.Unit('kg meter2 second-3')
print(watt)             # kg meter*meter/(second*second*second)
print(watt.symbol)      # W

another_watt = watt * 1
print(another_watt)            # watt -> changed
print(another_watt.symbol)     # W

watt_meter = watt * cf_units.Unit('meter')
print(watt_meter)            # meter^3-kilogram-second^-3  -> verbose
print(watt_meter.symbol)     # m3.kg.s-3
```

**Before merging: Further changes in doc strings might be necessary.**