### PR TITLE
Replace all hashes (#) in a unit with 1 to make them dimensionless 

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2017, Met Office
+# (C) British Crown Copyright 2015 - 2018, Met Office
 #
 # This file is part of cf_units.
 #

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1047,6 +1047,9 @@ class Unit(_OrderedHashable):
         if unit.endswith(" since epoch"):
             unit = unit.replace("epoch", EPOCH)
 
+        if "#" in unit:
+            unit = unit.replace("#", "1")
+
         if unit.lower() in _UNKNOWN_UNIT:
             # TODO - removing the option of an unknown unit. Currently
             # the auto generated MOSIG rules are missing units on a

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -39,6 +39,12 @@ class Test___init__(unittest.TestCase):
         with self.assertRaises(TypeError):
             u = Unit('hours since 1970-01-01 00:00:00', calendar=5)
 
+    def test_hash_replacement(self):
+        hash_unit = 'm # s-1'
+        expected = 'm 1 s-1'
+        u = Unit(hash_unit)
+        self.assertEqual(u, expected)
+
 
 class Test_convert__calendar(unittest.TestCase):
 

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2017, Met Office
+# (C) British Crown Copyright 2015 - 2018, Met Office
 #
 # This file is part of cf_units.
 #


### PR DESCRIPTION
When `Unit` class is passed a `unit` with a `'#'` in it this is now handled by replacing it with a `'1'`

This closes issue #88