### PR TITLE
Fix travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,16 @@ language: python
 
 python:
   - 2.7
-  - 3.4
-  - 3.5
+  - 3.6
 
 install:
   # Install miniconda
   # -----------------
   - export CONDA_BASE=http://repo.continuum.io/miniconda/Miniconda
   - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-      wget ${CONDA_BASE}-3.7.0-Linux-x86_64.sh -O miniconda.sh;
+      wget ${CONDA_BASE}2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget ${CONDA_BASE}3-3.7.0-Linux-x86_64.sh -O miniconda.sh;
+      wget ${CONDA_BASE}3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -28,7 +27,6 @@ install:
 
   # Customise the testing environment.
   # ----------------------------------
-  - conda config --add channels scitools
   - conda install --quiet udunits2 --file requirements.txt --file requirements-dev.txt
   - pip install coveralls
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
-pytest
 pep8
 pip

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,14 @@
+from __future__ import absolute_import, division, print_function
+
 import os
 import sys
 
-from setuptools import setup
-from setuptools.command.test import test as TestCommand
+from setuptools import find_packages, setup
 import versioneer
 
 
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.verbose = True
-
-    def run_tests(self):
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
+NAME = 'cf_units'
+DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 def file_walk_relative(top, remove=''):
@@ -29,35 +23,30 @@ def file_walk_relative(top, remove=''):
         for file in files:
             yield os.path.join(root, file).replace(remove, '')
 
-rootpath = os.path.abspath(os.path.dirname(__file__))
-
 
 def read(*parts):
-    with open(os.path.join(rootpath, *parts), 'rb') as f:
+    with open(os.path.join(DIR, *parts), 'rb') as f:
         return f.read().decode('utf-8')
 
-
-long_description = '{}'.format(read('README.rst'))
-
-cmdclass = {'test': PyTest}
-cmdclass.update(versioneer.get_cmdclass())
 
 require = read('requirements.txt')
 install_requires = [r.strip() for r in require.splitlines()]
 
+
 setup(
-    name='cf_units',
+    name=NAME,
     version=versioneer.get_version(),
-    url='https://github.com/SciTools/cf_units',
+    url='https://github.com/SciTools/{}'.format(NAME),
     author='Met Office',
     description='Units of measure as required by the Climate and Forecast (CF) metadata conventions',
-    long_description=long_description,
-    packages=['cf_units', 'cf_units/tests'],
+    long_description='{}'.format(read('README.rst')),
+    packages=find_packages(),
     package_data={'cf_units': list(file_walk_relative('cf_units/etc',
                                                       remove='cf_units/'))},
     data_files=[('share/doc/cf_units',
                  ['COPYING', 'COPYING.LESSER', 'README.rst'])],
     install_requires=install_requires,
-    tests_require=['pytest', 'pep8'],
-    cmdclass=cmdclass
+    tests_require=['pep8'],
+    test_suite='{}.tests'.format(NAME),
+    cmdclass=versioneer.get_cmdclass()
     )


### PR DESCRIPTION
This PR fixes the currently broken `travis-ci` tests.

I decided to flip back to `unittest` from `pytest`, simply because I couldn't get it to work using `pytest` (as it stood)

I also stopped `travis-ci` from pulling `udunits2` from `scitools` :scream: , in preference from `defaults`. Moving to a more recent version of `udunits2` i.e. `2.2.20` from `scitools` to `2.2.25` from `anaconda` highlighted that we had broken tests.

The tests were attempting to perform cross calendar `datetime` comparisions, which you can't do now (and I didn't know that you could ever do that) 