### PR TITLE
Added calendar aliased for standard and gregorian.

### DIFF
--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -556,7 +556,7 @@ class Test_stringify(unittest.TestCase):
     def test___repr___time_unit(self):
         u = Unit("hours since 2007-01-15 12:06:00",
                  calendar=unit.CALENDAR_STANDARD)
-        exp = "Unit('hours since 2007-01-15 12:06:00', calendar='standard')"
+        exp = "Unit('hours since 2007-01-15 12:06:00', calendar='gregorian')"
         self.assertEqual(repr(u), exp)
 
 

--- a/doc/source/utilities.rst
+++ b/doc/source/utilities.rst
@@ -16,3 +16,6 @@ These are documented below.
 
 .. autofunction:: date2num
 .. autofunction:: num2date
+
+.. autodata:: CALENDARS
+.. autodata:: CALENDAR_ALIASES


### PR DESCRIPTION
Coerces the constructor to convert the word "standard" into "gregorian". Not necessarily the best way of doing things, but probably the least invasive.

The impact is that the calendar "standard" is lost, and replaced with "gregorian". That could have a downstream impact on tools that want to preserve this information in a loss-less form.

Closes #80.