### PR TITLE
Fix multi-dim array unit conversion with unit.convert(...)

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1837,7 +1837,10 @@ class Unit(_OrderedHashable):
                     ctype = result.dtype.type
                     # Utilise global convenience dictionary
                     # _cv_convert_array
+                    shape = result.shape
+                    result.shape = (np.prod(shape), )
                     _cv_convert_array[ctype](ut_converter, result, result)
+                    result.shape = shape
                 else:
                     if ctype not in _cv_convert_scalar:
                         raise ValueError('Invalid target type. Can only '

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -649,6 +649,13 @@ class Test_convert(unittest.TestCase):
         result = u.convert(expected * 1609.344, v)
         np.testing.assert_array_equal(result, expected)
 
+    def test_convert_array_multidim(self):
+        u = Unit('meter')
+        v = Unit('mile')
+        expected = (np.arange(2, dtype=np.float32) + 1).reshape([1, 1, 2, 1])
+        result = u.convert(expected * 1609.344, v)
+        np.testing.assert_array_equal(result, expected)
+
     def test_incompatible_units(self):
         u = Unit('m')
         v = Unit('V')


### PR DESCRIPTION
In the ctypes implementation we used to get the raw array data pointer and pass that through, now we are going through Cython and hence the errors seen in #97:

```
    ======================================================================
    ERROR: test_circular_subset (iris.tests.experimental.regrid.test_regrid_area_weighted_rectilinear_src_and_grid.TestAreaWeightedRegrid)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "iris/tests/experimental/regrid/test_regrid_area_weighted_rectilinear_src_and_grid.py", line 532, in test_circular_subset
        res = regrid_area_weighted(src, dest)
      File "iris/experimental/regrid.py", line 722, in regrid_area_weighted_rectilinear_src_and_grid
        src_x_bounds = _get_bounds_in_units(src_x, x_units, dtype)
      File "iris/experimental/regrid.py", line 349, in _get_bounds_in_units
        return coord.units.convert(coord.bounds.astype(dtype), units).astype(dtype)
      File "cf_units/__init__.py", line 1840, in convert
        _cv_convert_array[ctype](ut_converter, result, result)
      File "cf_units/_udunits2.pyx", line 308, in cf_units._udunits2.convert_doubles
        def convert_doubles(Converter converter, np.ndarray[np.float64_t] in_, np.ndarray[np.float64_t] out):
    ValueError: Buffer has wrong number of dimensions (expected 1, got 2)
```

Closes #97.