### PR TITLE
Avoid copying the README and license information into the prefix root.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,6 @@ setup(
     packages=find_packages(),
     package_data={'cf_units': list(file_walk_relative('cf_units/etc',
                                                       remove='cf_units/'))},
-    data_files=[('share/doc/cf_units',
-                 ['COPYING', 'COPYING.LESSER', 'README.rst'])],
     install_requires=install_requires,
     tests_require=['pep8'],
     test_suite='{}.tests'.format(NAME),


### PR DESCRIPTION
Necessary since #103, but also removes the completely unnecessary copying of the license information into ${PREFIX}/COPYING. No other package does this. It is a distributor's (e.g. conda-forge) responsibility to ensure the license information is distributed.