### PR TITLE
Support the case where cython is not available at setup.py.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.txt
 include *.md
-recursive-include cf_units *.py *.py *.pxd *.pyx
+recursive-include cf_units *.py *.py *.pxd *.pyx *.c
 include cf_units/etc/site.cfg.template
 include CHANGES COPYING COPYING.LESSER INSTALL
 include versioneer.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.txt
 include *.md
-recursive-include cf_units *.py *.py *.pxd *.pyx *.c
+recursive-include cf_units *.py *.pxd *.pyx *.c
 include cf_units/etc/site.cfg.template
 include CHANGES COPYING COPYING.LESSER INSTALL
 include versioneer.py

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,8 @@ import versioneer
 # Default to using cython, but use the .c files if it doesn't exist
 try:
     from Cython.Build import cythonize
-    USE_CYTHON = True
 except ImportError:
-    USE_CYTHON = False
+    cythonize = False
 
 NAME = 'cf_units'
 DIR = os.path.abspath(os.path.dirname(__file__))
@@ -46,7 +45,7 @@ else:
     extra_extension_args = dict(
         runtime_library_dirs=library_dirs)
 
-ext = 'pyx' if USE_CYTHON else 'c'
+ext = 'pyx' if cythonize else 'c'
 
 udunits_ext = Extension('cf_units._udunits2',
                         ['cf_units/_udunits2.{}'.format(ext)],
@@ -55,7 +54,7 @@ udunits_ext = Extension('cf_units._udunits2',
                         libraries=['udunits2'],
                         **extra_extension_args)
 
-if USE_CYTHON:
+if cythonize:
     [udunits_ext] = cythonize(udunits_ext)
 
 cmdclass = {}

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,17 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
-from Cython.Distutils import build_ext
 from distutils.sysconfig import get_config_var
 import numpy as np
 from setuptools import setup, Extension, find_packages
 import versioneer
 
+# Default to using cython, but use the .c files if it doesn't exist
+try:
+    from Cython.Build import cythonize
+    USE_CYTHON = True
+except ImportError:
+    USE_CYTHON = False
 
 NAME = 'cf_units'
 DIR = os.path.abspath(os.path.dirname(__file__))
@@ -40,14 +45,20 @@ if sys.platform.startswith('win'):
 else:
     extra_extension_args = dict(
         runtime_library_dirs=library_dirs)
+
+ext = 'pyx' if USE_CYTHON else 'c'
+
 udunits_ext = Extension('cf_units._udunits2',
-                        ['cf_units/_udunits2.pyx'],
+                        ['cf_units/_udunits2.{}'.format(ext)],
                         include_dirs=include_dirs + [np.get_include()],
                         library_dirs=library_dirs,
                         libraries=['udunits2'],
                         **extra_extension_args)
 
-cmdclass = {'build_ext': build_ext}
+if USE_CYTHON:
+    [udunits_ext] = cythonize(udunits_ext)
+
+cmdclass = {}
 cmdclass.update(versioneer.get_cmdclass())
 
 require = read('requirements.txt')


### PR DESCRIPTION
setup.py currently requires cython. The cython documentation discourages that: http://docs.cython.org/en/latest/src/reference/compilation.html#distributing-cython-modules

I've implemented the middle ground - if we have cython, use it. If we don't have cython, use the c files that are shipped as part of the sdist (e.g. pypi & conda-forge).

The problem with this approach (as it is currently implemented), is that the C files need to be complied when building the sdist. That is fine if we have cython installed, but could cause the pyx and c to be out of synch if we build the sdist without cython installed. Rather than build that complexity into the setup.py though, I was quite comfortable with the idea that a cf_units developer cutting a release is likely to have cython installed when building the sdist.

Closes #106