### PR TITLE
Add method to unit to create a latex consumable string

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1294,7 +1294,7 @@ class Unit(_OrderedHashable):
             result = self.format(UT_DEFINITION)
         return result
 
-    def latex(self, separator='{\cdot}'):
+    def latex(self, separator=r'{\cdot}'):
         """
         *(read-only)* A latex consumable string form of the unit.
 
@@ -1317,7 +1317,7 @@ class Unit(_OrderedHashable):
             >>> import cf_units
             >>> u = cf_units.Unit('kg kg-1')
             >>> u.latex()
-            '{kg}{\cdot}{kg}^{-1}'
+            r'{kg}{\cdot}{kg}^{-1}'
 
         """
 
@@ -1329,20 +1329,20 @@ class Unit(_OrderedHashable):
                 (unit, power) = match.group(1, 3)
                 # Replace micro with \mu, only prefix that requires this
                 if unit.startswith('micro'):
-                    newunitstr = '{\mu}{' + unit.replace('micro', '') + '}'
+                    newunitstr = r'{\mu}{' + unit.replace('micro', '') + r'}'
                 else:
-                    newunitstr = '{' + unit + '}'
+                    newunitstr = r'{' + unit + r'}'
                 # Add power to string if it exists
                 if power:
-                    newunitstr += '^{' + power + '}'
+                    newunitstr += r'^{' + power + r'}'
             else:
                 # Return original string if it doesn't match regexp
-                newunitstr = '{' + unitstr + '}'
+                newunitstr = r'{' + unitstr + r'}'
             return newunitstr
 
         # Must use str(unit) here as unit.definition resolves units to
         # closest form, e.g. kg kg^-1 => 1
-        re_unit = re.compile('(^[^-+\d\^]+)([\^]?)([-+]?[\d]*)$')
+        re_unit = re.compile(r'(^[^-+\d\^]+)([\^]?)([-+]?[\d]*)$')
         latex_str = [conv_latex(unit, re_unit) for unit in str(self).split()]
         # Join using pre-defined separator
         return separator.join(latex_str)

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1317,7 +1317,7 @@ class Unit(_OrderedHashable):
             >>> import cf_units
             >>> u = cf_units.Unit('kg kg-1')
             >>> u.latex()
-            'kg{\cdot}kg^{-1}'
+            '{kg}{\cdot}{kg}^{-1}'
 
         """
 

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1294,7 +1294,7 @@ class Unit(_OrderedHashable):
             result = self.format(UT_DEFINITION)
         return result
 
-    def latex(self, separator='{\\cdot}'):
+    def latex(self, separator='{\cdot}'):
         """
         *(read-only)* A latex consumable string form of the unit.
 
@@ -1317,7 +1317,7 @@ class Unit(_OrderedHashable):
             >>> import cf_units
             >>> u = cf_units.Unit('kg kg-1')
             >>> u.latex()
-            '{kg}{\\cdot}{kg}^{-1}'
+            '{kg}{\cdot}{kg}^{-1}'
 
         """
 
@@ -1329,7 +1329,7 @@ class Unit(_OrderedHashable):
                 (unit, power) = match.group(1, 3)
                 # Replace micro with \mu, only prefix that requires this
                 if unit.startswith('micro'):
-                    newunitstr = '{\\mu}{' + unit.replace('micro', '') + '}'
+                    newunitstr = '{\mu}{' + unit.replace('micro', '') + '}'
                 else:
                     newunitstr = '{' + unit + '}'
                 # Add power to string if it exists
@@ -1342,7 +1342,7 @@ class Unit(_OrderedHashable):
 
         # Must use str(unit) here as unit.definition resolves units to
         # closest form, e.g. kg kg^-1 => 1
-        re_unit = re.compile('(^[^-+\\d\\^]+)([\\^]?)([-+]?[\\d]*)$')
+        re_unit = re.compile('(^[^-+\d\^]+)([\^]?)([-+]?[\d]*)$')
         latex_str = [conv_latex(unit, re_unit) for unit in str(self).split()]
         # Join using pre-defined separator
         return separator.join(latex_str)

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1294,7 +1294,7 @@ class Unit(_OrderedHashable):
             result = self.format(UT_DEFINITION)
         return result
 
-    def latex(self, separator='{\cdot}'):
+    def latex(self, separator='{\\cdot}'):
         """
         *(read-only)* A latex consumable string form of the unit.
 
@@ -1329,7 +1329,7 @@ class Unit(_OrderedHashable):
                 (unit, power) = match.group(1, 3)
                 # Replace micro with \mu, only prefix that requires this
                 if unit.startswith('micro'):
-                    newunitstr = '{\mu}{' + unit.replace('micro', '') + '}'
+                    newunitstr = '{\\mu}{' + unit.replace('micro', '') + '}'
                 else:
                     newunitstr = '{' + unit + '}'
                 # Add power to string if it exists
@@ -1342,7 +1342,7 @@ class Unit(_OrderedHashable):
 
         # Must use str(unit) here as unit.definition resolves units to
         # closest form, e.g. kg kg^-1 => 1
-        re_unit = re.compile('(^[^-+\d\^]+)([\^]?)([-+]?[\d]*)$')
+        re_unit = re.compile('(^[^-+\\d\\^]+)([\\^]?)([-+]?[\\d]*)$')
         latex_str = [conv_latex(unit, re_unit) for unit in str(self).split()]
         # Join using pre-defined separator
         return separator.join(latex_str)

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1317,7 +1317,7 @@ class Unit(_OrderedHashable):
             >>> import cf_units
             >>> u = cf_units.Unit('kg kg-1')
             >>> u.latex()
-            '{kg}{\cdot}{kg}^{-1}'
+            '{kg}{\\cdot}{kg}^{-1}'
 
         """
 

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -210,6 +210,21 @@ class Test_definition(unittest.TestCase):
         self.assertEqual(u.definition, unit._NO_UNIT_SYMBOL)
 
 
+class Test_latex(unittest.TestCase):
+
+    def test_basic(self):
+        u = Unit('kg kg-1')
+        self.assertEqual(u.latex(), 'kg{\cdot}kg^{-1}')
+
+    def test_separator(self):
+        u = Unit('kg kg-1')
+        self.assertEqual(u.latex(separator=' '), 'kg kg^{-1}')
+
+    def test_micro(self):
+        u = Unit('microW m-2')
+        self.assertEqual(u.latex(), '{\mu}W{\cdot}m{-2}')
+
+
 class Test__apply_offset(unittest.TestCase):
 
     def test_add_integer_offset(self):

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -214,15 +214,15 @@ class Test_latex(unittest.TestCase):
 
     def test_basic(self):
         u = Unit('kg kg-1')
-        self.assertEqual(u.latex(), 'kg{\cdot}kg^{-1}')
+        self.assertEqual(u.latex(), '{kg}{\cdot}{kg}^{-1}')
 
     def test_separator(self):
         u = Unit('kg kg-1')
-        self.assertEqual(u.latex(separator=' '), 'kg kg^{-1}')
+        self.assertEqual(u.latex(separator=' '), '{kg} {kg}^{-1}')
 
     def test_micro(self):
         u = Unit('microW m-2')
-        self.assertEqual(u.latex(), '{\mu}W{\cdot}m{-2}')
+        self.assertEqual(u.latex(), '{\mu}{W}{\cdot}{m}^{-2}')
 
 
 class Test__apply_offset(unittest.TestCase):

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -214,7 +214,7 @@ class Test_latex(unittest.TestCase):
 
     def test_basic(self):
         u = Unit('kg kg-1')
-        self.assertEqual(u.latex(), '{kg}{\\cdot}{kg}^{-1}')
+        self.assertEqual(u.latex(), '{kg}{\cdot}{kg}^{-1}')
 
     def test_separator(self):
         u = Unit('kg kg-1')
@@ -222,7 +222,7 @@ class Test_latex(unittest.TestCase):
 
     def test_micro(self):
         u = Unit('microW m-2')
-        self.assertEqual(u.latex(), '{\\mu}{W}{\\cdot}{m}^{-2}')
+        self.assertEqual(u.latex(), '{\mu}{W}{\cdot}{m}^{-2}')
 
 
 class Test__apply_offset(unittest.TestCase):

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -214,15 +214,15 @@ class Test_latex(unittest.TestCase):
 
     def test_basic(self):
         u = Unit('kg kg-1')
-        self.assertEqual(u.latex(), '{kg}{\cdot}{kg}^{-1}')
+        self.assertEqual(u.latex(), r'{kg}{\cdot}{kg}^{-1}')
 
     def test_separator(self):
         u = Unit('kg kg-1')
-        self.assertEqual(u.latex(separator=' '), '{kg} {kg}^{-1}')
+        self.assertEqual(u.latex(separator=' '), r'{kg} {kg}^{-1}')
 
     def test_micro(self):
         u = Unit('microW m-2')
-        self.assertEqual(u.latex(), '{\mu}{W}{\cdot}{m}^{-2}')
+        self.assertEqual(u.latex(), r'{\mu}{W}{\cdot}{m}^{-2}')
 
 
 class Test__apply_offset(unittest.TestCase):

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -214,7 +214,7 @@ class Test_latex(unittest.TestCase):
 
     def test_basic(self):
         u = Unit('kg kg-1')
-        self.assertEqual(u.latex(), '{kg}{\cdot}{kg}^{-1}')
+        self.assertEqual(u.latex(), '{kg}{\\cdot}{kg}^{-1}')
 
     def test_separator(self):
         u = Unit('kg kg-1')
@@ -222,7 +222,7 @@ class Test_latex(unittest.TestCase):
 
     def test_micro(self):
         u = Unit('microW m-2')
-        self.assertEqual(u.latex(), '{\mu}{W}{\cdot}{m}^{-2}')
+        self.assertEqual(u.latex(), '{\\mu}{W}{\\cdot}{m}^{-2}')
 
 
 class Test__apply_offset(unittest.TestCase):


### PR DESCRIPTION
A useful feature of Matplotlib is that it understands latex markup. Therefore it is useful to be able to create a string in latex markup for the units that can be used with Matplotlib.

The method splits the unit's str() representation into individual components, which are then modified to include appropriate {, } and ^. e.g. s-2 => {s}^{-2}. These are then combined back together using an optionally specified separator (default is {\cdot}).

There are several caveats to this method. The output for str(unit) must have each individual unit instance be space separated, e.g. 'Pa m s-2'. I am not sure how the method will cope with itself as input, obviously ideally this should remain unchanged. I have used str(unit) as the string to be processed as the output from unit.format() always has the units resolved to it's lowest form, e.g. kg kg-1 => 1, which is not always  desired.