### PR TITLE
Make sure create proper unknown unit when "doing maths" with units

### DIFF
--- a/.idea/cf-units.iml
+++ b/.idea/cf-units.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.4" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/cf-units.iml" filepath="$PROJECT_DIR$/.idea/cf-units.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,3 @@
+---
+linters:
+    flake8:

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1514,7 +1514,8 @@ class Unit(_OrderedHashable):
             raise ValueError("Cannot %s a 'no-unit'." % op_label)
 
         if self.is_unknown() or other.is_unknown():
-            result = _Unit(_CATEGORY_UNKNOWN, None)
+            result = _Unit(_CATEGORY_UNKNOWN, _ud.NULL_UNIT,
+                           origin=_UNKNOWN_UNIT_STRING)
         else:
             try:
                 ut_unit = op_func(self.ut_unit, other.ut_unit)

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -373,13 +373,12 @@ class Test_multiply(unittest.TestCase):
     def test_multiply_with_unknown_unit(self):
         u = Unit('unknown')
         v = Unit('meters')
-        self.assertIsNotNone
         self.assertTrue((u * v).is_unknown())
         self.assertTrue((v * u).is_unknown())
-        self.assertIsNotNone((u * v).origin)
-        self.assertIsNotNone((v * u).origin)
-        self.assertIsNotNone((u * v).ut_unit)
-        self.assertIsNotNone((v * u).ut_unit)
+        self.assertEqual((u * v).origin, unit._UNKNOWN_UNIT_STRING)
+        self.assertEqual((v * u).origin, unit._UNKNOWN_UNIT_STRING)
+        self.assertEqual((u * v).ut_unit, unit._ud.NULL_UNIT)
+        self.assertEqual((v * u).ut_unit, unit._ud.NULL_UNIT)
 
     def test_multiply_with_no_unit(self):
         u = Unit('meters')
@@ -421,6 +420,10 @@ class Test_divide(unittest.TestCase):
         v = Unit('meters')
         self.assertTrue((u / v).is_unknown())
         self.assertTrue((v / u).is_unknown())
+        self.assertEqual((u / v).origin, unit._UNKNOWN_UNIT_STRING)
+        self.assertEqual((v / u).origin, unit._UNKNOWN_UNIT_STRING)
+        self.assertEqual((u / v).ut_unit, unit._ud.NULL_UNIT)
+        self.assertEqual((v / u).ut_unit, unit._ud.NULL_UNIT)
 
     def test_divide_with_no_unit(self):
         u = Unit('meters')

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -373,8 +373,13 @@ class Test_multiply(unittest.TestCase):
     def test_multiply_with_unknown_unit(self):
         u = Unit('unknown')
         v = Unit('meters')
+        self.assertIsNotNone
         self.assertTrue((u * v).is_unknown())
         self.assertTrue((v * u).is_unknown())
+        self.assertIsNotNone((u * v).origin)
+        self.assertIsNotNone((v * u).origin)
+        self.assertIsNotNone((u * v).ut_unit)
+        self.assertIsNotNone((v * u).ut_unit)
 
     def test_multiply_with_no_unit(self):
         u = Unit('meters')


### PR DESCRIPTION
When you "do maths" with units that contain the unknown unit the result is not a complete unit and hence has the possibility of causing problems downstream. In one particular example it causes a SEGFAULT in python due to udunits2 not being able to handle the units. For example:

a = Unit('unknown')
b = a * a

Then b is Unit('?'), not Unit('unknown')

If you then run _udunits2.compare(b.ut_unit, b.ut_unit), this causes a SEGFAULT in python3 given b.ut_unit is None. Why this is the case is an issue for udunits2 given this is not a problem in python2.

This change will make sure that the output of an operation that includes the unknown unit is itself a fully formed unknown unit.