### PR TITLE
setup.py tidy + cython coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,9 @@
 
 [run]
 branch = True
+plugins = Cython.Coverage
+include =
+    cf_units/*
 omit = 
     setup.py
     versioneer.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ install:
   # cf_units.
   - PREFIX=${HOME}/miniconda/envs/${ENV_NAME}
 
-  - pip install -e .
+  - CYTHON_COVERAGE=1 pip install -e .
 
 script:
-  - coverage run -m pytest cf_units
+  - pytest
 
 after_success: coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ exclude =
     etc
     versioneer.py
 
+[aliases]
+test = pytest
+
 [tool:pytest]
 testpaths =
     cf_units/tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,15 @@ exclude =
     versioneer.py
 
 [tool:pytest]
+testpaths =
+    cf_units/tests
 addopts = 
-    --doctest-modules
+    -ra
+    -v
     --cov-config .coveragerc
-doctest_optionflags= NORMALIZE_WHITESPACE ELLIPSIS
+    --cov=cf_units
+    --cov-report term-missing
+    --doctest-modules
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    ELLIPSIS

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,4 @@ addopts =
     --cov=cf_units
     --cov-report term-missing
     --doctest-modules
-doctest_optionflags =
-    NORMALIZE_WHITESPACE
-    ELLIPSIS
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS

--- a/setup.py
+++ b/setup.py
@@ -65,18 +65,18 @@ def load(fname):
     return result
 
 
-def description():
+def long_description():
     fname = os.path.join(BASEDIR, 'README.md')
     with open(fname, 'rb') as fi:
         result = fi.read().decode('utf-8')
     return result
 
 
-
 include_dir = get_config_var('INCLUDEDIR')
 include_dirs = [include_dir] if include_dir is not None else []
 library_dir = get_config_var('LIBDIR')
 library_dirs = [library_dir] if library_dir is not None else []
+
 if sys.platform.startswith('win'):
     extra_extension_args = {}
 else:
@@ -118,7 +118,7 @@ setup(
     url='https://github.com/SciTools/{}'.format(NAME),
     author='Met Office',
     description=description,
-    long_description=description(),
+    long_description=long_description(),
     long_description_content_type='text/markdown',
     packages=find_packages(),
     package_data={'cf_units': list(file_walk_relative('cf_units/etc',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 from distutils.sysconfig import get_config_var
 import numpy as np
-from setuptools import setup, Extension, find_packages
+from setuptools import Command, Extension, find_packages, setup
 import versioneer
 
 # Default to using cython, but use the .c files if it doesn't exist
@@ -14,8 +14,35 @@ try:
 except ImportError:
     cythonize = False
 
+COMPILER_DIRECTIVES = {}
+DEFINE_MACROS = None
+FLAG_COVERAGE = '--cython-coverage'  # custom flag enabling Cython line tracing
+BASEDIR = os.path.abspath(os.path.dirname(__file__))
 NAME = 'cf-units'
-DIR = os.path.abspath(os.path.dirname(__file__))
+CFUNITS_DIR = os.path.join(BASEDIR, 'cf_units')
+
+
+class CleanCython(Command):
+    description = 'Purge artifacts built by Cython'
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        for rpath, _, fnames in os.walk(CFUNITS_DIR):
+            for fname in fnames:
+                _, ext = os.path.splitext(fname)
+                if ext in ('.pyc', '.pyo', '.c', '.so'):
+                    artifact = os.path.join(rpath, fname)
+                    if os.path.exists(artifact):
+                        print('clean: removing file {!r}'.format(artifact))
+                        os.remove(artifact)
+                    else:
+                        print('clean: skipping file {!r}'.format(artifact))
 
 
 def file_walk_relative(top, remove=''):
@@ -31,9 +58,19 @@ def file_walk_relative(top, remove=''):
             yield os.path.join(root, file).replace(remove, '')
 
 
-def read(*parts):
-    with open(os.path.join(DIR, *parts), 'rb') as f:
-        return f.read().decode('utf-8')
+def load(fname):
+    result = []
+    with open(fname, 'r') as fi:
+        result = [package.strip() for package in fi.readlines()]
+    return result
+
+
+def description():
+    fname = os.path.join(BASEDIR, 'README.md')
+    with open(fname, 'rb') as fi:
+        result = fi.read().decode('utf-8')
+    return result
+
 
 
 include_dir = get_config_var('INCLUDEDIR')
@@ -48,21 +85,29 @@ else:
 
 ext = 'pyx' if cythonize else 'c'
 
+if FLAG_COVERAGE in sys.argv or os.environ.get('CYTHON_COVERAGE', None):
+    COMPILER_DIRECTIVES = {'linetrace': True}
+    DEFINE_MACROS = [('CYTHON_TRACE', '1'),
+                     ('CYTHON_TRACE_NOGIL', '1')]
+    if FLAG_COVERAGE in sys.argv:
+        sys.argv.remove(FLAG_COVERAGE)
+    print('enable: "linetrace" Cython compiler directive')
+
 udunits_ext = Extension('cf_units._udunits2',
                         ['cf_units/_udunits2.{}'.format(ext)],
                         include_dirs=include_dirs + [np.get_include()],
                         library_dirs=library_dirs,
                         libraries=['udunits2'],
+                        define_macros=DEFINE_MACROS,
                         **extra_extension_args)
 
 if cythonize:
-    [udunits_ext] = cythonize(udunits_ext)
+    [udunits_ext] = cythonize(udunits_ext,
+                              compiler_directives=COMPILER_DIRECTIVES,
+                              language_level=2)
 
-cmdclass = {}
+cmdclass = {'clean_cython': CleanCython}
 cmdclass.update(versioneer.get_cmdclass())
-
-require = read('requirements.txt')
-install_requires = [r.strip() for r in require.splitlines()]
 
 description = ('Units of measure as required by the Climate and Forecast (CF) '
                'metadata conventions')
@@ -73,13 +118,14 @@ setup(
     url='https://github.com/SciTools/{}'.format(NAME),
     author='Met Office',
     description=description,
-    long_description='{}'.format(read('README.md')),
+    long_description=description(),
     long_description_content_type='text/markdown',
     packages=find_packages(),
     package_data={'cf_units': list(file_walk_relative('cf_units/etc',
                                                       remove='cf_units/'))},
-    install_requires=install_requires,
-    tests_require=['pep8'],
+    install_requires=load('requirements.txt'),
+    setup_requires=['pytest-runner'],
+    tests_require=load('requirements-dev.txt'),
     test_suite='cf_units.tests',
     cmdclass=cmdclass,
     ext_modules=[udunits_ext]


### PR DESCRIPTION
This PR tidies the `setup.py` and adds `pytest` coverage for `Cython`.

Developers now run tests with `python setup.py pytest` (as well as `pytest`)

There is also a convenience command to clean up a build with `python setup.py clean_cython`.

Turn on `Cython` line tracing by either:

- `python setup.py --cython-coverage build_ext --inplace` or
- `CYTHON_COVERAGE=1 python setup.py build_ext --inplace` or
- `CYTHON_COVERAGE=1 pip install -e .` or
- `CYTHON_COVERAGE=1 python setup.py pytest`
