### PR TITLE
Fix python setup.py test to run doctests.

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2018, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of cf-units.
 #
@@ -1878,7 +1878,7 @@ class Unit(_OrderedHashable):
             ...                   calendar=cf_units.CALENDAR_STANDARD)
             >>> ut = u.utime()
             >>> print(ut.num2date(2))
-            1970-01-01 02:00:00.000006
+            1970-01-01 02:00:00
 
         """
         if self.calendar is None:
@@ -1924,8 +1924,8 @@ class Unit(_OrderedHashable):
             >>> import datetime
             >>> u = cf_units.Unit('hours since 1970-01-01 00:00:00',
             ...                   calendar=cf_units.CALENDAR_STANDARD)
-            >>> u.date2num(datetime.datetime(1970, 1, 1, 5))
-            5.00000000372529
+            >>> round(u.date2num(datetime.datetime(1970, 1, 1, 5)))
+            5.0
             >>> u.date2num([datetime.datetime(1970, 1, 1, 5),
             ...             datetime.datetime(1970, 1, 1, 6)])
             array([5., 6.])

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ test = pytest
 
 [tool:pytest]
 testpaths =
-    cf_units/tests
+    cf_units/
 addopts = 
     -ra
     -v


### PR DESCRIPTION
By defining the tests to be in ``cf_units/tests`` we are excluding doctests found in ``cf_units`` when running ``python setup.py test`` (which is the case in our CI). Locally, I personally run ``pytest cf_units`` which actually fails with a few doctests.

This changes the config so that ``python setup.py test`` identifies the doctests in ``cf_units``, and fixes the few tests that were failing.


For the record, it took me a deal of time to figure out what was going on. I was making sure that ``setup.cfg`` could actually handle pytest aliases *and* addopts, started down the line of implementing a ``pytest.ini`` to see if that was the issue. A couple of issues that came up (https://github.com/pytest-dev/pytest-runner/issues/18, https://github.com/astropy/astropy/issues/6513) were red-herrings - this was simply fixed by the fact that the testpaths were pointing to the test folder, and not the whole source folder! 