### PR TITLE
Allowed __repr__ of a poorly constructed Unit.

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1128,7 +1128,7 @@ class Unit(_OrderedHashable):
             False
 
         """
-        return self.category == _CATEGORY_UNKNOWN
+        return self.category == _CATEGORY_UNKNOWN or self.ut_unit is None
 
     def is_no_unit(self):
         """

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2018, Met Office
+# (C) British Crown Copyright 2010 - 2019, Met Office
 #
 # This file is part of cf-units.
 #
@@ -746,6 +746,12 @@ class Test_is_unknown(unittest.TestCase):
     def test_known_unit(self):
         u = Unit('meters')
         self.assertFalse(u.is_unknown())
+
+    def test_no_ut_pointer(self):
+        # Test that a unit that was poorly constructed has a
+        # degree of tolerance by making it unknown.
+        # https://github.com/SciTools/cf-units/issues/133 refers.
+        self.assertTrue(Unit.__new__(Unit).is_unknown())
 
 
 class Test_is_no_unit(unittest.TestCase):

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2018, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of cf-units.
 #
@@ -247,6 +247,15 @@ class Test_is_long_time_interval(unittest.TestCase):
         unit = Unit('K')
         result = unit.is_long_time_interval()
         self.assertFalse(result)
+
+
+class Test_format(unittest.TestCase):
+    def test_invalid_ut_unit(self):
+        # https://github.com/SciTools/cf-units/issues/133 flagged up that
+        # format should be a little more tolerant of a Unit that has not been
+        # constructed correctly when using pytest.
+        unit = Unit.__new__(Unit)
+        self.assertEqual(unit.format(), 'unknown')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Rationale

Addresses the comment in https://github.com/SciTools/cf-units/issues/133#issuecomment-456051865, namely that pytest tries calling ``Unit.__repr__`` when a test fails, even if that test was the constructor of ``Unit``. Essentially, unless https://github.com/pytest-dev/pytest/issues/4659 is solved directly, we should strive to have a repr that can be a little more fault tolerant (rather than Segmentation Faulting as it currently does).

# Implications 

 * ``is_unknown`` now also checks to see if the ``ut_unit`` pointer is None, if it is, the unit is considered unknown.