### PR TITLE
Tidy up the propagation of exceptions from UDUNITS2

### DIFF
--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -28,6 +28,7 @@ import copy
 import datetime as datetime
 import operator
 import six
+import re
 
 try:
     from operator import truediv
@@ -189,6 +190,18 @@ class Test_format(unittest.TestCase):
         u = Unit('watt')
         self.assertEqual(u.format(unit.UT_DEFINITION), 'm2.kg.s-3')
 
+    def test_format_multiple_options(self):
+        u = Unit('watt')
+        self.assertEqual(
+            u.format([unit.UT_NAMES, unit.UT_DEFINITION]),
+            'meter^2-kilogram-second^-3')
+
+    def test_format_multiple_options_utf8(self):
+        u = Unit('watt')
+        self.assertEqual(
+            u.format([unit.UT_NAMES, unit.UT_DEFINITION, unit.UT_UTF8]),
+            u'meter²·kilogram·second⁻³')
+
     def test_format_unknown(self):
         u = Unit('?')
         self.assertEqual(u.format(), 'unknown')
@@ -196,6 +209,14 @@ class Test_format(unittest.TestCase):
     def test_format_no_unit(self):
         u = Unit('nounit')
         self.assertEqual(u.format(), 'no_unit')
+
+    def test_format_names_utf8(self):
+        u = Unit('m2')
+        self.assertEqual(u.format([unit.UT_UTF8, unit.UT_NAMES]), u'meter²')
+
+    def test_format_latin1(self):
+        u = Unit('m2')
+        self.assertEqual(u.format(unit.UT_LATIN1), u'm²')
 
 
 class Test_name(unittest.TestCase):
@@ -368,6 +389,12 @@ class Test_log(unittest.TestCase):
     def test_base_10(self):
         u = Unit('hPa')
         self.assertEqual(u.log(10), 'lg(re 100 Pa)')
+
+    def test_negative(self):
+        u = Unit('hPa')
+        msg = re.escape("Failed to calculate logorithmic base of Unit('hPa')")
+        with six.assertRaisesRegex(self, ValueError, msg):
+            u.log(-1)
 
     def test_not_numeric(self):
         u = Unit('hPa')


### PR DESCRIPTION
Modernises the exception raising when propagating from udunits2.

In python 3 we have a syntax to allow us to control whether to show multiple tracebacks (super useful for the case of exceptions being raised in multiple threads). **This functionality is the default in python 3**. Essentially, the following code:

```
def foo():
    raise ValueError('Inside foo')

def bar():
    try:
        foo()
    except Exception as err:
        raise ValueError('bar')

bar()
```

```
$ python2 raise_from.py 
Traceback (most recent call last):
  File "raise_from.py", line 15, in <module>
    bar()
  File "raise_from.py", line 11, in bar
    raise ValueError('bar')
ValueError: bar
```

```
python3 raise_from.py 
Traceback (most recent call last):
  File "raise_from.py", line 9, in bar
    foo()
  File "raise_from.py", line 2, in foo
    raise ValueError('Inside foo')
ValueError: Inside foo

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "raise_from.py", line 15, in <module>
    bar()
  File "raise_from.py", line 11, in bar
    raise ValueError('bar')
ValueError: bar
```

The same is true for existing cf_units:

```
python2 -c "import cf_units as u; u.Unit('2^m')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "cf_units/__init__.py", line 836, in __init__
    self._propogate_error('Failed to parse unit "%s"' % unit, e)
  File "cf_units/__init__.py", line 871, in _propogate_error
    raise ValueError('[%s] %s%s' % (ud_err.status_msg(), msg, error_msg))
ValueError: [UT_SUCCESS] Failed to parse unit "2^m"
```

```
python3 -c "import cf_units as u; u.Unit('2^m')"
Traceback (most recent call last):
  File "/Users/pelson/dev/scitools/cf-units/cf_units/__init__.py", line 834, in __init__
    ut_unit = _ud.parse(_ud_system, unit.encode('ascii'), UT_ASCII)
  File "cf_units/_udunits2.pyx", line 268, in cf_units._udunits2.parse
    return wrap_unit(system, cunit)
  File "cf_units/_udunits2.pyx", line 123, in cf_units._udunits2.wrap_unit
    _raise_error()
  File "cf_units/_udunits2.pyx", line 196, in cf_units._udunits2._raise_error
    raise UdunitsError(status, errnum)
cf_units._udunits2.UdunitsError: UT_SUCCESS

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/pelson/dev/scitools/cf-units/cf_units/__init__.py", line 836, in __init__
    self._propogate_error('Failed to parse unit "%s"' % unit, e)
  File "/Users/pelson/dev/scitools/cf-units/cf_units/__init__.py", line 871, in _propogate_error
    raise ValueError('[%s] %s%s' % (ud_err.status_msg(), msg, error_msg))
ValueError: [UT_SUCCESS] Failed to parse unit "2^m"
```


With this change we now get good exceptions in both python2 and python3:

```
python2 -c "import cf_units as u; u.Unit('2^m')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "cf_units/__init__.py", line 853, in __init__
    six.raise_from(value_error, None)
  File "/Users/pelson/dev/scitools/cf-units/env_py27/lib/python2.7/site-packages/six.py", line 737, in raise_from
    raise value
ValueError: [UT_SUCCESS] Failed to parse unit "2^m"
```

```
$ python3 -c "import cf_units as u; u.Unit('2^m')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/pelson/dev/scitools/cf-units/cf_units/__init__.py", line 853, in __init__
    six.raise_from(value_error, None)
  File "<string>", line 3, in raise_from
ValueError: [UT_SUCCESS] Failed to parse unit "2^m"
```
