### PR TITLE
Fixes issue #144.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ if FLAG_COVERAGE in sys.argv or os.environ.get('CYTHON_COVERAGE', None):
         sys.argv.remove(FLAG_COVERAGE)
     print('enable: "linetrace" Cython compiler directive')
 
+
 def numpy_build_ext(pars):
     from setuptools.command.build_ext import build_ext as _build_ext
 
@@ -103,6 +104,7 @@ def numpy_build_ext(pars):
             self.include_dirs.append(numpy.get_include())
 
     return build_ext(pars)
+
 
 udunits_ext = Extension('cf_units._udunits2',
                         ['cf_units/_udunits2.{}'.format(ext)],


### PR DESCRIPTION
Fixes issue #144 as per the method documented by [ead](https://stackoverflow.com/users/5769463/ead) at https://stackoverflow.com/a/54138355.  This delays the `numpy.get_include()` call until after the packages listed in `setup_requires` are installed.

Removes the need to manually run:
```
pip install numpy
```
before installing `cf-units`.

I have tested this for:

- Python 2.7
- Python 3.5
- Python 3.6
- Python 3.7