### PR TITLE
Deligate equality to other if conversion to Unit fails.

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1731,7 +1731,10 @@ class Unit(_OrderedHashable):
             True
 
         """
-        other = as_unit(other)
+        try:
+            other = as_unit(other)
+        except ValueError:
+            return NotImplemented
 
         # Compare category (i.e. unknown, no_unit, etc.).
         if self.category != other.category:

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -667,6 +667,10 @@ class Test_equality(unittest.TestCase):
         v = Unit('no_unit')
         self.assertNotEqual(u, v)
 
+    def test_not_implemented(self):
+        u = Unit('meter')
+        self.assertFalse(u == {})
+
 
 class Test_non_equality(unittest.TestCase):
 
@@ -694,6 +698,10 @@ class Test_non_equality(unittest.TestCase):
     def test_no_unit(self):
         u = Unit('no_unit')
         self.assertFalse(u != 'no_unit')
+
+    def test_not_implemented(self):
+        u = Unit('meter')
+        self.assertNotEqual(u, {})
 
 
 class Test_convert(unittest.TestCase):


### PR DESCRIPTION
This fixes issue #149 by returning `NotImplemented` if `other` is not or cannot be converted to a `Unit`.  By doing this `Unit` allows `other` to make the decision or in the case that neither can determine equality Python will fallback on identity.