### PR TITLE
unpin numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 six
 cftime!=1.0.2.1
 cython
-numpy<1.17.0
+numpy
 antlr4-python3-runtime==4.7.2; python_version >= '3'
 
 # udunits2 cannot be installed with pip, and it is expected to be installed separately.

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
     package_data={'cf_units': list(file_walk_relative('cf_units/etc',
                                                       remove='cf_units/'))},
     install_requires=load('requirements.txt'),
-    setup_requires=['pytest-runner', 'numpy<1.17.0'],
+    setup_requires=['pytest-runner', 'numpy'],
     tests_require=load('requirements-dev.txt'),
     test_suite='cf_units.tests',
     cmdclass=cmdclass,


### PR DESCRIPTION
NumPy 1.17.0 has now been released, so unpin, see https://github.com/numpy/numpy/releases/tag/v1.17.0

Follow-up from https://github.com/SciTools/cf-units/pull/153