### PR TITLE
remove cython as a run dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coveralls
+cython
 jinja2
 pep8
 pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 six
 cftime!=1.0.2.1
-cython
 numpy
 antlr4-python3-runtime==4.7.2; python_version >= '3'
 

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
     package_data={'cf_units': list(file_walk_relative('cf_units/etc',
                                                       remove='cf_units/'))},
     install_requires=load('requirements.txt'),
-    setup_requires=['pytest-runner', 'numpy'],
+    setup_requires=['pytest-runner', 'numpy', 'cython'],
     tests_require=load('requirements-dev.txt'),
     test_suite='cf_units.tests',
     cmdclass=cmdclass,


### PR DESCRIPTION
The current setup requires `cython` to be install at run time and  that breaks the `pip check` and other dependency checking commands.