### PR TITLE
Fix doctests

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -442,14 +442,14 @@ def date2num(date, unit, calendar):
 
         >>> import cf_units
         >>> import datetime
-        >>> dt1 = datetime.datetime(1970, 1, 1, 6, 0, 0)
+        >>> dt1 = datetime.datetime(1970, 1, 1, 6, 30, 0)
         >>> dt2 = datetime.datetime(1970, 1, 1, 7, 0, 0)
         >>> cf_units.date2num(dt1, 'hours since 1970-01-01 00:00:00',
         ...               cf_units.CALENDAR_STANDARD)
-        6.0
+        6.5
         >>> cf_units.date2num([dt1, dt2], 'hours since 1970-01-01 00:00:00',
         ...               cf_units.CALENDAR_STANDARD)
-        array([6., 7.])
+        array([6.5, 7.0])
 
     """
 
@@ -1944,8 +1944,8 @@ class Unit(_OrderedHashable):
             >>> import datetime
             >>> u = cf_units.Unit('hours since 1970-01-01 00:00:00',
             ...                   calendar=cf_units.CALENDAR_STANDARD)
-            >>> round(u.date2num(datetime.datetime(1970, 1, 1, 5)))
-            5.0
+            >>> u.date2num(datetime.datetime(1970, 1, 1, 5, 30))
+            5.5
             >>> u.date2num([datetime.datetime(1970, 1, 1, 5),
             ...             datetime.datetime(1970, 1, 1, 6)])
             array([5., 6.])

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -462,7 +462,6 @@ def date2num(date, unit, calendar):
     if unit_string.endswith(" since epoch"):
         unit_string = unit_string.replace("epoch", EPOCH)
     unit_inst = Unit(unit_string, calendar=calendar)
-
     return unit_inst.date2num(date)
 
 

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -462,7 +462,7 @@ def date2num(date, unit, calendar):
     if unit_string.endswith(" since epoch"):
         unit_string = unit_string.replace("epoch", EPOCH)
     unit_inst = Unit(unit_string, calendar=calendar)
-    
+
     return unit_inst.date2num(date)
 
 

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2020, Met Office
+# (C) British Crown Copyright 2015 - 2021, Met Office
 #
 # This file is part of cf-units.
 #
@@ -443,13 +443,13 @@ def date2num(date, unit, calendar):
         >>> import cf_units
         >>> import datetime
         >>> dt1 = datetime.datetime(1970, 1, 1, 6, 30, 0)
-        >>> dt2 = datetime.datetime(1970, 1, 1, 7, 0, 0)
+        >>> dt2 = datetime.datetime(1970, 1, 1, 7, 30, 0)
         >>> cf_units.date2num(dt1, 'hours since 1970-01-01 00:00:00',
         ...               cf_units.CALENDAR_STANDARD)
         6.5
         >>> cf_units.date2num([dt1, dt2], 'hours since 1970-01-01 00:00:00',
         ...               cf_units.CALENDAR_STANDARD)
-        array([6.5, 7.0])
+        array([6.5, 7.5])
 
     """
 
@@ -1946,9 +1946,9 @@ class Unit(_OrderedHashable):
             ...                   calendar=cf_units.CALENDAR_STANDARD)
             >>> u.date2num(datetime.datetime(1970, 1, 1, 5, 30))
             5.5
-            >>> u.date2num([datetime.datetime(1970, 1, 1, 5),
-            ...             datetime.datetime(1970, 1, 1, 6)])
-            array([5., 6.])
+            >>> u.date2num([datetime.datetime(1970, 1, 1, 5, 30),
+            ...             datetime.datetime(1970, 1, 1, 6, 30)])
+            array([5.5, 6.5])
 
         """
 

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -462,6 +462,7 @@ def date2num(date, unit, calendar):
     if unit_string.endswith(" since epoch"):
         unit_string = unit_string.replace("epoch", EPOCH)
     unit_inst = Unit(unit_string, calendar=calendar)
+    
     return unit_inst.date2num(date)
 
 


### PR DESCRIPTION
Some tweaks to get the doctests passing.  Added in 30 minutes to the datetimes that are input to `date2num` so we'll get a decimal and therefore more obviously a float in the output.  Also removed the `round` from the Unit method version so it's consistent with the function.

For failure example see https://travis-ci.org/github/SciTools/cf-units/jobs/768092165#L1103