### PR TITLE
Updates for cftime 1.5.0

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -506,8 +506,9 @@ def num2date(time_value, unit, calendar, only_use_cftime_datetimes=True):
 
     Like the :func:`matplotlib.dates.num2date` function, except that it allows
     for different units and calendars.  If
-    unit = 'days since 1970-01-01 00:00:00' and
-    calendar = 'proleptic_gregorian',
+    unit = 'days since 1970-01-01 00:00:00',
+    calendar = 'proleptic_gregorian' and
+    only_use_cftime_datetimes = False
     behaves the same as matplotlib with the default epoch of 1970-01-01.
 
     By default, the datetime instances returned are cftime.datetime objects,

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -587,7 +587,7 @@ def _num2date_to_nearest_second(time_value, unit,
 
     Returns:
         datetime, or numpy.ndarray of datetime object.
-        
+
     """
     time_values = np.asanyarray(time_value)
     shape = time_values.shape

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -418,9 +418,10 @@ def date2num(date, unit, calendar):
     applied to the returned numeric values.
 
     Like the :func:`matplotlib.dates.date2num` function, except that it allows
-    for different units and calendars.  Behaves the same as if
-    unit = 'days since 0001-01-01 00:00:00' and
-    calendar = 'proleptic_gregorian'.
+    for different units and calendars.  If
+    unit = 'days since 1970-01-01 00:00:00' and
+    calendar = 'proleptic_gregorian',
+    behaves the same as matplotlib with the default epoch of 1970-01-01.
 
     Args:
 
@@ -502,11 +503,12 @@ def num2date(time_value, unit, calendar, only_use_cftime_datetimes=True):
     calendar arguments. The returned datetime object represent UTC with
     no time-zone offset, even if the specified unit contain a time-zone
     offset.
-
+    
     Like the :func:`matplotlib.dates.num2date` function, except that it allows
-    for different units and calendars.  Behaves the same if
-    unit = 'days since 001-01-01 00:00:00'}
-    calendar = 'proleptic_gregorian'.
+    for different units and calendars.  If
+    unit = 'days since 1970-01-01 00:00:00' and
+    calendar = 'proleptic_gregorian',
+    behaves the same as matplotlib with the default epoch of 1970-01-01.
 
     By default, the datetime instances returned are cftime.datetime objects,
     regardless of calendar.  If the only_use_cftime_datetimes keyword is set to

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -503,7 +503,7 @@ def num2date(time_value, unit, calendar, only_use_cftime_datetimes=True):
     calendar arguments. The returned datetime object represent UTC with
     no time-zone offset, even if the specified unit contain a time-zone
     offset.
-    
+
     Like the :func:`matplotlib.dates.num2date` function, except that it allows
     for different units and calendars.  If
     unit = 'days since 1970-01-01 00:00:00' and

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -494,7 +494,7 @@ def _discard_microsecond(date):
     return result
 
 
-def num2date(time_value, unit, calendar, only_use_cftime_datetimes=False):
+def num2date(time_value, unit, calendar, only_use_cftime_datetimes=True):
     """
     Return datetime encoding of numeric time value (resolution of 1 second).
 
@@ -508,14 +508,11 @@ def num2date(time_value, unit, calendar, only_use_cftime_datetimes=False):
     unit = 'days since 001-01-01 00:00:00'}
     calendar = 'proleptic_gregorian'.
 
-    By default, the datetime instances returned are 'real' python datetime
-    objects if the date falls in the Gregorian calendar (i.e.
-    calendar='proleptic_gregorian', or calendar = 'standard' or 'gregorian'
-    and the date is after 1582-10-15). Otherwise, they are 'phony' datetime
-    objects which support some but not all the methods of 'real' python
-    datetime objects.  This is because the python datetime module cannot
-    use the 'proleptic_gregorian' calendar, even before the switch
-    occured from the Julian calendar in 1582. The datetime instances
+    By default, the datetime instances returned are cftime.datetime objects,
+    regardless of calendar.  If the only_use_cftime_datetimes keyword is set to
+    False, they are datetime.datetime objects if the date falls in the
+    Gregorian calendar (i.e. calendar is 'proleptic_gregorian', 'standard' or
+    'gregorian' and the date is after 1582-10-15). The datetime instances
     do not contain a time-zone offset, even if the specified unit
     contains one.
 
@@ -540,7 +537,7 @@ def num2date(time_value, unit, calendar, only_use_cftime_datetimes=False):
     * only_use_cftime_datetimes (bool):
         If True, will always return cftime datetime objects, regardless of
         calendar.  If False, returns datetime.datetime instances where
-        possible.  Defaults to False.
+        possible.  Defaults to True.
 
     Returns:
         datetime, or numpy.ndarray of datetime object.
@@ -573,7 +570,7 @@ def num2date(time_value, unit, calendar, only_use_cftime_datetimes=False):
 
 
 def _num2date_to_nearest_second(time_value, utime,
-                                only_use_cftime_datetimes=False):
+                                only_use_cftime_datetimes=True):
     """
     Return datetime encoding of numeric time value with respect to the given
     time reference units, with a resolution of 1 second.
@@ -586,7 +583,7 @@ def _num2date_to_nearest_second(time_value, utime,
     * only_use_cftime_datetimes (bool):
         If True, will always return cftime datetime objects, regardless of
         calendar.  If False, returns datetime.datetime instances where
-        possible.  Defaults to False.
+        possible.  Defaults to True.
 
     Returns:
         datetime, or numpy.ndarray of datetime object.
@@ -1984,7 +1981,7 @@ class Unit(_OrderedHashable):
         date = _discard_microsecond(date)
         return cdf_utime.date2num(date)
 
-    def num2date(self, time_value, only_use_cftime_datetimes=False):
+    def num2date(self, time_value, only_use_cftime_datetimes=True):
         """
         Returns a datetime-like object calculated from the numeric time
         value using the current calendar and the unit time reference.
@@ -1993,12 +1990,13 @@ class Unit(_OrderedHashable):
         '<time-unit> since <time-origin>'
         i.e. 'hours since 1970-01-01 00:00:00'
 
-        By default, the datetime objects returned are 'real' Python datetime
-        objects if the date falls in the Gregorian calendar (i.e. the calendar
-        is 'standard', 'gregorian', or 'proleptic_gregorian' and the
-        date is after 1582-10-15). Otherwise a 'phoney' datetime-like
-        object (cftime.datetime) is returned which can handle dates
-        that don't exist in the Proleptic Gregorian calendar.
+        By default, the datetime instances returned are cftime.datetime
+        objects, regardless of calendar.  If the only_use_cftime_datetimes
+        keyword is set to False, they are datetime.datetime objects if the date
+        falls in the Gregorian calendar (i.e. calendar is
+        'proleptic_gregorian', 'standard' or gregorian' and the date is after
+        1582-10-15). The datetime instances do not contain a time-zone offset,
+        even if the specified unit contains one.
 
         Works for scalars, sequences and numpy arrays. Returns a scalar
         if input is a scalar, else returns a numpy array.
@@ -2013,7 +2011,7 @@ class Unit(_OrderedHashable):
         * only_use_cftime_datetimes (bool):
             If True, will always return cftime datetime objects, regardless of
             calendar.  If False, returns datetime.datetime instances where
-            possible.  Defaults to False.
+            possible.  Defaults to True.
 
         Returns:
             datetime, or numpy.ndarray of datetime object.

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -359,14 +359,14 @@ def julian_day2date(julian_day, calendar):
 
         >>> import cf_units
         >>> import datetime
-        >>> dt = datetime.datetime(1970, 1, 1, 0, 0, 0)
+        >>> dt = cftime.datetime(1970, 1, 1, 0, 0, 0)
         >>> jd = cf_units.date2julian_day(dt, cf_units.CALENDAR_STANDARD)
         >>> print(cf_units.julian_day2date(jd, cf_units.CALENDAR_STANDARD))
         1970-01-01 00:00:00
 
     """
 
-    return cftime.DateFromJulianDay(julian_day, calendar)
+    return cftime.datetime.fromordinal(julian_day, calendar)
 
 
 def date2julian_day(date, calendar):
@@ -398,13 +398,13 @@ def date2julian_day(date, calendar):
 
         >>> import cf_units
         >>> import datetime
-        >>> cf_units.date2julian_day(datetime.datetime(1970, 1, 1, 0, 0, 0),
+        >>> cf_units.date2julian_day(cftime.datetime(1970, 1, 1, 0, 0, 0),
         ...                          cf_units.CALENDAR_STANDARD)
         2440587.5...
 
     """
 
-    return cftime.JulianDayFromDate(date, calendar)
+    return date.toordinal(fractional=True)
 
 
 def date2num(date, unit, calendar):

--- a/cf_units/tests/integration/test__num2date_to_nearest_second.py
+++ b/cf_units/tests/integration/test__num2date_to_nearest_second.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2020, Met Office
+# (C) British Crown Copyright 2016 - 2021, Met Office
 #
 # This file is part of cf-units.
 #
@@ -32,10 +32,12 @@ class Test(unittest.TestCase):
         self.uhours = cftime.utime('hours since 1970-01-01', calendar)
         self.udays = cftime.utime('days since 1970-01-01', calendar)
 
-    def check_dates(self, nums, utimes, expected):
+    def check_dates(self, nums, utimes, expected, only_cftime=False):
         for num, utime, exp in zip(nums, utimes, expected):
-            res = _num2date_to_nearest_second(num, utime)
+            res = _num2date_to_nearest_second(
+                num, utime, only_use_cftime_datetimes=only_cftime)
             self.assertEqual(exp, res)
+            self.assertIsInstance(res, type(exp))
 
     def check_timedelta(self, nums, utimes, expected):
         for num, utime, exp in zip(nums, utimes, expected):
@@ -51,6 +53,7 @@ class Test(unittest.TestCase):
         exp = datetime.datetime(1970, 1, 1, 0, 0, 5)
         res = _num2date_to_nearest_second(num, utime)
         self.assertEqual(exp, res)
+        self.assertIsInstance(res, datetime.datetime)
 
     def test_sequence(self):
         utime = cftime.utime('seconds since 1970-01-01',  'gregorian')
@@ -102,6 +105,27 @@ class Test(unittest.TestCase):
                     datetime.datetime(1971, 8, 24)]
 
         self.check_dates(nums, utimes, expected)
+
+    def test_simple_gregorian_cftime_type(self):
+        self.setup_units('gregorian')
+        nums = [20., 40.,
+                75., 150.,
+                8., 16.,
+                300., 600.]
+        utimes = [self.useconds, self.useconds,
+                  self.uminutes, self.uminutes,
+                  self.uhours, self.uhours,
+                  self.udays, self.udays]
+        expected = [cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 20),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 40),
+                    cftime.DatetimeGregorian(1970, 1, 1, 1, 15),
+                    cftime.DatetimeGregorian(1970, 1, 1, 2, 30),
+                    cftime.DatetimeGregorian(1970, 1, 1, 8),
+                    cftime.DatetimeGregorian(1970, 1, 1, 16),
+                    cftime.DatetimeGregorian(1970, 10, 28),
+                    cftime.DatetimeGregorian(1971, 8, 24)]
+
+        self.check_dates(nums, utimes, expected, only_cftime=True)
 
     def test_fractional_gregorian(self):
         self.setup_units('gregorian')

--- a/cf_units/tests/integration/test__num2date_to_nearest_second.py
+++ b/cf_units/tests/integration/test__num2date_to_nearest_second.py
@@ -54,7 +54,7 @@ class Test(unittest.TestCase):
         exp = datetime.datetime(1970, 1, 1, 0, 0, 5)
         res = _num2date_to_nearest_second(num, unit)
         self.assertEqual(exp, res)
-        self.assertIsInstance(res, cftime.DatetimeGregorian)
+        self.assertIsInstance(res, cftime.datetime)
 
     def test_sequence(self):
         unit = cf_units.Unit('seconds since 1970-01-01',  'gregorian')
@@ -117,14 +117,15 @@ class Test(unittest.TestCase):
                  self.uminutes, self.uminutes,
                  self.uhours, self.uhours,
                  self.udays, self.udays]
-        expected = [cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 20),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 40),
-                    cftime.DatetimeGregorian(1970, 1, 1, 1, 15),
-                    cftime.DatetimeGregorian(1970, 1, 1, 2, 30),
-                    cftime.DatetimeGregorian(1970, 1, 1, 8),
-                    cftime.DatetimeGregorian(1970, 1, 1, 16),
-                    cftime.DatetimeGregorian(1970, 10, 28),
-                    cftime.DatetimeGregorian(1971, 8, 24)]
+        expected = [
+            cftime.datetime(1970, 1, 1, 0, 0, 20, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 0, 0, 40, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 1, 15, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 2, 30, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 8, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 16, calendar='gregorian'),
+            cftime.datetime(1970, 10, 28, calendar='gregorian'),
+            cftime.datetime(1971, 8, 24, calendar='gregorian')]
 
         self.check_dates(nums, units, expected)
 
@@ -136,12 +137,13 @@ class Test(unittest.TestCase):
         units = [self.uminutes, self.uminutes,
                  self.uhours, self.uhours,
                  self.udays, self.udays]
-        expected = [cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 5),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 10),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 15),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 30),
-                    cftime.DatetimeGregorian(1970, 1, 1, 8),
-                    cftime.DatetimeGregorian(1970, 1, 1, 16)]
+        expected = [
+            cftime.datetime(1970, 1, 1, 0, 0, 5, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 0, 0, 10, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 0, 15, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 0, 30, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 8, calendar='gregorian'),
+            cftime.datetime(1970, 1, 1, 16, calendar='gregorian')]
 
         self.check_dates(nums, units, expected)
 
@@ -150,13 +152,13 @@ class Test(unittest.TestCase):
         nums = [0.25, 0.5, 0.75,
                 1.5, 2.5, 3.5, 4.5]
         units = [self.useconds] * 7
-        expected = [cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 0),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 1),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 1),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 2),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 3),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 4),
-                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 5)]
+        expected = [cftime.datetime(1970, 1, 1, 0, 0, 0, calendar='gregorian'),
+                    cftime.datetime(1970, 1, 1, 0, 0, 1, calendar='gregorian'),
+                    cftime.datetime(1970, 1, 1, 0, 0, 1, calendar='gregorian'),
+                    cftime.datetime(1970, 1, 1, 0, 0, 2, calendar='gregorian'),
+                    cftime.datetime(1970, 1, 1, 0, 0, 3, calendar='gregorian'),
+                    cftime.datetime(1970, 1, 1, 0, 0, 4, calendar='gregorian'),
+                    cftime.datetime(1970, 1, 1, 0, 0, 5, calendar='gregorian')]
 
         self.check_dates(nums, units, expected)
 

--- a/cf_units/tests/integration/test__num2date_to_nearest_second.py
+++ b/cf_units/tests/integration/test__num2date_to_nearest_second.py
@@ -53,7 +53,7 @@ class Test(unittest.TestCase):
         exp = datetime.datetime(1970, 1, 1, 0, 0, 5)
         res = _num2date_to_nearest_second(num, utime)
         self.assertEqual(exp, res)
-        self.assertIsInstance(res, datetime.datetime)
+        self.assertIsInstance(res, cftime.DatetimeGregorian)
 
     def test_sequence(self):
         utime = cftime.utime('seconds since 1970-01-01',  'gregorian')
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
 
     # Gregorian Calendar tests
 
-    def test_simple_gregorian(self):
+    def test_simple_gregorian_py_datetime_type(self):
         self.setup_units('gregorian')
         nums = [20., 40.,
                 75., 150.,
@@ -104,9 +104,9 @@ class Test(unittest.TestCase):
                     datetime.datetime(1970, 10, 28),
                     datetime.datetime(1971, 8, 24)]
 
-        self.check_dates(nums, utimes, expected)
+        self.check_dates(nums, utimes, expected, only_cftime=False)
 
-    def test_simple_gregorian_cftime_type(self):
+    def test_simple_gregorian(self):
         self.setup_units('gregorian')
         nums = [20., 40.,
                 75., 150.,
@@ -125,7 +125,7 @@ class Test(unittest.TestCase):
                     cftime.DatetimeGregorian(1970, 10, 28),
                     cftime.DatetimeGregorian(1971, 8, 24)]
 
-        self.check_dates(nums, utimes, expected, only_cftime=True)
+        self.check_dates(nums, utimes, expected)
 
     def test_fractional_gregorian(self):
         self.setup_units('gregorian')
@@ -135,12 +135,12 @@ class Test(unittest.TestCase):
         utimes = [self.uminutes, self.uminutes,
                   self.uhours, self.uhours,
                   self.udays, self.udays]
-        expected = [datetime.datetime(1970, 1, 1, 0, 0, 5),
-                    datetime.datetime(1970, 1, 1, 0, 0, 10),
-                    datetime.datetime(1970, 1, 1, 0, 15),
-                    datetime.datetime(1970, 1, 1, 0, 30),
-                    datetime.datetime(1970, 1, 1, 8),
-                    datetime.datetime(1970, 1, 1, 16)]
+        expected = [cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 5),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 10),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 15),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 30),
+                    cftime.DatetimeGregorian(1970, 1, 1, 8),
+                    cftime.DatetimeGregorian(1970, 1, 1, 16)]
 
         self.check_dates(nums, utimes, expected)
 
@@ -149,13 +149,13 @@ class Test(unittest.TestCase):
         nums = [0.25, 0.5, 0.75,
                 1.5, 2.5, 3.5, 4.5]
         utimes = [self.useconds] * 7
-        expected = [datetime.datetime(1970, 1, 1, 0, 0, 0),
-                    datetime.datetime(1970, 1, 1, 0, 0, 1),
-                    datetime.datetime(1970, 1, 1, 0, 0, 1),
-                    datetime.datetime(1970, 1, 1, 0, 0, 2),
-                    datetime.datetime(1970, 1, 1, 0, 0, 3),
-                    datetime.datetime(1970, 1, 1, 0, 0, 4),
-                    datetime.datetime(1970, 1, 1, 0, 0, 5)]
+        expected = [cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 0),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 1),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 1),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 2),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 3),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 4),
+                    cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 5)]
 
         self.check_dates(nums, utimes, expected)
 

--- a/cf_units/tests/integration/test__num2date_to_nearest_second.py
+++ b/cf_units/tests/integration/test__num2date_to_nearest_second.py
@@ -114,9 +114,9 @@ class Test(unittest.TestCase):
                 8., 16.,
                 300., 600.]
         units = [self.useconds, self.useconds,
-                  self.uminutes, self.uminutes,
-                  self.uhours, self.uhours,
-                  self.udays, self.udays]
+                 self.uminutes, self.uminutes,
+                 self.uhours, self.uhours,
+                 self.udays, self.udays]
         expected = [cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 20),
                     cftime.DatetimeGregorian(1970, 1, 1, 0, 0, 40),
                     cftime.DatetimeGregorian(1970, 1, 1, 1, 15),
@@ -227,9 +227,9 @@ class Test(unittest.TestCase):
                 8., 16.,
                 300., 600.]
         units = [self.useconds, self.useconds,
-                  self.uminutes, self.uminutes,
-                  self.uhours, self.uhours,
-                  self.udays, self.udays]
+                 self.uminutes, self.uminutes,
+                 self.uhours, self.uhours,
+                 self.udays, self.udays]
         # Expected results in (days, seconds) delta from unit epoch.
         expected = [(0, nums[0]),
                     (0, nums[1]),
@@ -248,8 +248,8 @@ class Test(unittest.TestCase):
                 15./60., 30./60.,
                 8./24., 16./24.]
         units = [self.uminutes, self.uminutes,
-                  self.uhours, self.uhours,
-                  self.udays, self.udays]
+                 self.uhours, self.uhours,
+                 self.udays, self.udays]
         # Expected results in (days, seconds) delta from unit epoch.
         expected = [(0, nums[0]*60),
                     (0, nums[1]*60),

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -989,7 +989,8 @@ class TestNumsAndDates(unittest.TestCase):
                  calendar=unit.CALENDAR_STANDARD)
         res = u.num2date(1)
         self.assertEqual(str(res), '2010-11-02 13:00:00')
-        self.assertIsInstance(res, cftime.DatetimeGregorian)
+        self.assertEqual(res.calendar, 'gregorian')
+        self.assertIsInstance(res, cftime.datetime)
 
     def test_num2date_py_datetime_type(self):
         u = Unit('hours since 2010-11-02 12:00:00',

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -989,14 +989,14 @@ class TestNumsAndDates(unittest.TestCase):
                  calendar=unit.CALENDAR_STANDARD)
         res = u.num2date(1)
         self.assertEqual(str(res), '2010-11-02 13:00:00')
-        self.assertIsInstance(res, datetime.datetime)
+        self.assertIsInstance(res, cftime.DatetimeGregorian)
 
-    def test_num2date_cftime_type(self):
+    def test_num2date_py_datetime_type(self):
         u = Unit('hours since 2010-11-02 12:00:00',
                  calendar=unit.CALENDAR_STANDARD)
-        res = u.num2date(1, only_use_cftime_datetimes=True)
+        res = u.num2date(1, only_use_cftime_datetimes=False)
         self.assertEqual(str(res), '2010-11-02 13:00:00')
-        self.assertIsInstance(res, cftime.DatetimeGregorian)
+        self.assertIsInstance(res, datetime.datetime)
 
     def test_date2num(self):
         u = Unit('hours since 2010-11-02 12:00:00',

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) British Crown Copyright 2010 - 2020, Met Office
+# (C) British Crown Copyright 2010 - 2021, Met Office
 #
 # This file is part of cf-units.
 #
@@ -29,6 +29,7 @@ import re
 from operator import truediv
 
 import numpy as np
+import cftime
 
 import cf_units as unit
 from cf_units import suppress_errors
@@ -262,7 +263,7 @@ class Test__apply_offset(unittest.TestCase):
     def test_not_numerical_offset(self):
         u = Unit('meter')
         with self.assertRaisesRegex(TypeError,
-                                   'unsupported operand type'):
+                                    'unsupported operand type'):
             operator.add(u, 'not_a_number')
 
     def test_unit_unknown(self):
@@ -986,7 +987,16 @@ class TestNumsAndDates(unittest.TestCase):
     def test_num2date(self):
         u = Unit('hours since 2010-11-02 12:00:00',
                  calendar=unit.CALENDAR_STANDARD)
-        self.assertEqual(str(u.num2date(1)), '2010-11-02 13:00:00')
+        res = u.num2date(1)
+        self.assertEqual(str(res), '2010-11-02 13:00:00')
+        self.assertIsInstance(res, datetime.datetime)
+
+    def test_num2date_cftime_type(self):
+        u = Unit('hours since 2010-11-02 12:00:00',
+                 calendar=unit.CALENDAR_STANDARD)
+        res = u.num2date(1, only_use_cftime_datetimes=True)
+        self.assertEqual(str(res), '2010-11-02 13:00:00')
+        self.assertIsInstance(res, cftime.DatetimeGregorian)
 
     def test_date2num(self):
         u = Unit('hours since 2010-11-02 12:00:00',

--- a/doc/source/utilities.rst
+++ b/doc/source/utilities.rst
@@ -11,9 +11,6 @@ These are documented below.
 .. autofunction:: encode_clock
 .. autofunction:: decode_time
 
-.. autofunction:: julian_day2date
-.. autofunction:: date2julian_day
-
 .. autofunction:: date2num
 .. autofunction:: num2date
 


### PR DESCRIPTION
Closes #166.  As well as the `utime` object, the julian date functions were also removed at https://github.com/Unidata/cftime/pull/235 and the note in the [changelog](https://github.com/Unidata/cftime/blob/master/Changelog) says they are replaced by `toordinal` and `fromordinal`.

Note that the first commit here is from #165, which was included in v2.1.5.  I have then changed the default behaviour of the various `num2date` functions to return a `cftime` object, consistent with the `cftime.num2date` function.  This goes some way to closing #161, though I have not here exposed the `only_use_python_datetimes` option.  I agree that that would be desirable, but it would be easy to add in a separate PR and I think there is already more than enough here for the reviewer to wade through!