### PR TITLE
num2pydate

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -503,6 +503,25 @@ def num2date(
     )
 
 
+def num2pydate(time_value, unit, calendar):
+    """
+    Convert time value(s) to python datetime.datetime objects, or raise an
+    exception if this is not possible.  Same as::
+
+        num2date(time_value, unit, calendar,
+                 only_use_cftime_datetimes=False,
+                 only_use_python_datetimes=True)
+
+    """
+    return num2date(
+        time_value,
+        unit,
+        calendar,
+        only_use_cftime_datetimes=False,
+        only_use_python_datetimes=True,
+    )
+
+
 def _num2date_to_nearest_second(
     time_value,
     unit,
@@ -2018,4 +2037,20 @@ class Unit(_OrderedHashable):
             self,
             only_use_cftime_datetimes=only_use_cftime_datetimes,
             only_use_python_datetimes=only_use_python_datetimes,
+        )
+
+    def num2pydate(self, time_value):
+        """
+        Convert time value(s) to python datetime.datetime objects, or raise an
+        exception if this is not possible.  Same as::
+
+            num2date(time_value, unit, calendar,
+                     only_use_cftime_datetimes=False,
+                     only_use_python_datetimes=True)
+
+        """
+        return self.num2date(
+            time_value,
+            only_use_cftime_datetimes=False,
+            only_use_python_datetimes=True,
         )

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -419,7 +419,13 @@ def _discard_microsecond(date):
     return result
 
 
-def num2date(time_value, unit, calendar, only_use_cftime_datetimes=True):
+def num2date(
+    time_value,
+    unit,
+    calendar,
+    only_use_cftime_datetimes=True,
+    only_use_python_datetimes=False,
+):
     """
     Return datetime encoding of numeric time value (resolution of 1 second).
 
@@ -459,6 +465,11 @@ def num2date(time_value, unit, calendar, only_use_cftime_datetimes=True):
         calendar.  If False, returns datetime.datetime instances where
         possible.  Defaults to True.
 
+    * only_use_python_datetimes (bool):
+        If True, will always return datetime.datetime instances where
+        possible, and raise an exception if not.  Ignored if
+        only_use_cftime_datetimes is True.  Defaults to False.
+
     Returns:
         datetime, or numpy.ndarray of datetime object.
 
@@ -486,12 +497,17 @@ def num2date(time_value, unit, calendar, only_use_cftime_datetimes=True):
         unit_string = unit_string.replace("epoch", EPOCH)
     unit_inst = Unit(unit_string, calendar=calendar)
     return unit_inst.num2date(
-        time_value, only_use_cftime_datetimes=only_use_cftime_datetimes
+        time_value,
+        only_use_cftime_datetimes=only_use_cftime_datetimes,
+        only_use_python_datetimes=only_use_python_datetimes,
     )
 
 
 def _num2date_to_nearest_second(
-    time_value, unit, only_use_cftime_datetimes=True
+    time_value,
+    unit,
+    only_use_cftime_datetimes=True,
+    only_use_python_datetimes=False,
 ):
     """
     Return datetime encoding of numeric time value with respect to the given
@@ -506,6 +522,11 @@ def _num2date_to_nearest_second(
         If True, will always return cftime datetime objects, regardless of
         calendar.  If False, returns datetime.datetime instances where
         possible.  Defaults to True.
+
+    * only_use_python_datetimes (bool):
+        If True, will always return datetime.datetime instances where
+        possible, and raise an exception if not.  Ignored if
+        only_use_cftime_datetimes is True.  Defaults to False.
 
     Returns:
         datetime, or numpy.ndarray of datetime object.
@@ -533,6 +554,7 @@ def _num2date_to_nearest_second(
         units=cftime_unit,
         calendar=unit.calendar,
         only_use_cftime_datetimes=only_use_cftime_datetimes,
+        only_use_python_datetimes=only_use_python_datetimes,
     )
     dates = cftime.num2date(time_values, **num2date_kwargs)
     try:
@@ -1933,7 +1955,12 @@ class Unit(_OrderedHashable):
         date = _discard_microsecond(date)
         return cftime.date2num(date, self.cftime_unit, self.calendar)
 
-    def num2date(self, time_value, only_use_cftime_datetimes=True):
+    def num2date(
+        self,
+        time_value,
+        only_use_cftime_datetimes=True,
+        only_use_python_datetimes=False,
+    ):
         """
         Returns a datetime-like object calculated from the numeric time
         value using the current calendar and the unit time reference.
@@ -1965,6 +1992,11 @@ class Unit(_OrderedHashable):
             calendar.  If False, returns datetime.datetime instances where
             possible.  Defaults to True.
 
+        * only_use_python_datetimes (bool):
+            If True, will always return datetime.datetime instances where
+            possible, and raise an exception if not.  Ignored if
+            only_use_cftime_datetimes is True.  Defaults to False.
+
         Returns:
             datetime, or numpy.ndarray of datetime object.
 
@@ -1985,4 +2017,5 @@ class Unit(_OrderedHashable):
             time_value,
             self,
             only_use_cftime_datetimes=only_use_cftime_datetimes,
+            only_use_python_datetimes=only_use_python_datetimes,
         )

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -2044,9 +2044,8 @@ class Unit(_OrderedHashable):
         Convert time value(s) to python datetime.datetime objects, or raise an
         exception if this is not possible.  Same as::
 
-            num2date(time_value, unit, calendar,
-                     only_use_cftime_datetimes=False,
-                     only_use_python_datetimes=True)
+            unit.num2date(time_value, only_use_cftime_datetimes=False,
+                          only_use_python_datetimes=True)
 
         """
         return self.num2date(

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -62,6 +62,7 @@ __all__ = [
     "encode_date",
     "encode_time",
     "num2date",
+    "num2pydate",
     "suppress_errors",
 ]
 

--- a/cf_units/tests/integration/test__num2date_to_nearest_second.py
+++ b/cf_units/tests/integration/test__num2date_to_nearest_second.py
@@ -253,12 +253,16 @@ class Test(unittest.TestCase):
         self.check_timedelta(nums, units, expected)
 
     def test_pydatetime_wrong_calendar(self):
-        unit = cf_units.Unit('days since 1970-01-01', calendar='360_day')
-        with self.assertRaisesRegex(ValueError,
-                                    'illegal calendar or reference date'):
+        unit = cf_units.Unit("days since 1970-01-01", calendar="360_day")
+        with self.assertRaisesRegex(
+            ValueError, "illegal calendar or reference date"
+        ):
             _num2date_to_nearest_second(
-                1, unit, only_use_cftime_datetimes=False,
-                only_use_python_datetimes=True)
+                1,
+                unit,
+                only_use_cftime_datetimes=False,
+                only_use_python_datetimes=True,
+            )
 
     # 365 day Calendar tests
 

--- a/cf_units/tests/integration/test__num2date_to_nearest_second.py
+++ b/cf_units/tests/integration/test__num2date_to_nearest_second.py
@@ -252,6 +252,14 @@ class Test(unittest.TestCase):
 
         self.check_timedelta(nums, units, expected)
 
+    def test_pydatetime_wrong_calendar(self):
+        unit = cf_units.Unit('days since 1970-01-01', calendar='360_day')
+        with self.assertRaisesRegex(ValueError,
+                                    'illegal calendar or reference date'):
+            _num2date_to_nearest_second(
+                1, unit, only_use_cftime_datetimes=False,
+                only_use_python_datetimes=True)
+
     # 365 day Calendar tests
 
     def test_simple_365_day(self):

--- a/cf_units/tests/integration/test_num2date.py
+++ b/cf_units/tests/integration/test_num2date.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2021, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Test function :func:`cf_units.num2date`."""
 
 import unittest

--- a/cf_units/tests/integration/test_num2date.py
+++ b/cf_units/tests/integration/test_num2date.py
@@ -17,9 +17,6 @@
 """Test function :func:`cf_units.date2num`."""
 
 import unittest
-import datetime
-
-import numpy as np
 
 from cf_units import num2date
 

--- a/cf_units/tests/integration/test_num2date.py
+++ b/cf_units/tests/integration/test_num2date.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
-"""Test function :func:`cf_units.date2num`."""
+"""Test function :func:`cf_units.num2date`."""
 
 import unittest
 

--- a/cf_units/tests/integration/test_num2date.py
+++ b/cf_units/tests/integration/test_num2date.py
@@ -12,12 +12,17 @@ from cf_units import num2date
 
 class Test(unittest.TestCase):
     def test_num2date_wrong_calendar(self):
-        with self.assertRaisesRegex(ValueError,
-                                    'illegal calendar or reference date'):
-            num2date(1, 'days since 1970-01-01', calendar='360_day',
-                     only_use_cftime_datetimes=False,
-                     only_use_python_datetimes=True)
+        with self.assertRaisesRegex(
+            ValueError, "illegal calendar or reference date"
+        ):
+            num2date(
+                1,
+                "days since 1970-01-01",
+                calendar="360_day",
+                only_use_cftime_datetimes=False,
+                only_use_python_datetimes=True,
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/cf_units/tests/integration/test_num2date.py
+++ b/cf_units/tests/integration/test_num2date.py
@@ -1,0 +1,37 @@
+# (C) British Crown Copyright 2021, Met Office
+#
+# This file is part of cf-units.
+#
+# cf-units is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cf-units is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+"""Test function :func:`cf_units.date2num`."""
+
+import unittest
+import datetime
+
+import numpy as np
+
+from cf_units import num2date
+
+
+class Test(unittest.TestCase):
+    def test_num2date_wrong_calendar(self):
+        with self.assertRaisesRegex(ValueError,
+                                    'illegal calendar or reference date'):
+            num2date(1, 'days since 1970-01-01', calendar='360_day',
+                     only_use_cftime_datetimes=False,
+                     only_use_python_datetimes=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cf_units/tests/integration/test_num2pydate.py
+++ b/cf_units/tests/integration/test_num2pydate.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
-"""Test function :func:`cf_units.date2num`."""
+"""Test function :func:`cf_units.num2pydate`."""
 
 import unittest
 import datetime

--- a/cf_units/tests/integration/test_num2pydate.py
+++ b/cf_units/tests/integration/test_num2pydate.py
@@ -19,8 +19,6 @@
 import unittest
 import datetime
 
-import numpy as np
-
 from cf_units import num2pydate
 
 

--- a/cf_units/tests/integration/test_num2pydate.py
+++ b/cf_units/tests/integration/test_num2pydate.py
@@ -5,8 +5,8 @@
 # licensing details.
 """Test function :func:`cf_units.num2pydate`."""
 
-import unittest
 import datetime
+import unittest
 
 from cf_units import num2pydate
 

--- a/cf_units/tests/integration/test_num2pydate.py
+++ b/cf_units/tests/integration/test_num2pydate.py
@@ -13,16 +13,17 @@ from cf_units import num2pydate
 
 class Test(unittest.TestCase):
     def test_num2pydate_simple(self):
-        result = num2pydate(1, 'days since 1970-01-01', calendar='standard')
+        result = num2pydate(1, "days since 1970-01-01", calendar="standard")
         expected = datetime.datetime(1970, 1, 2)
         self.assertEqual(result, expected)
         self.assertIsInstance(result, datetime.datetime)
 
     def test_num2pydate_wrong_calendar(self):
-        with self.assertRaisesRegex(ValueError,
-                                    'illegal calendar or reference date'):
-            num2pydate(1, 'days since 1970-01-01', calendar='360_day')
+        with self.assertRaisesRegex(
+            ValueError, "illegal calendar or reference date"
+        ):
+            num2pydate(1, "days since 1970-01-01", calendar="360_day")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/cf_units/tests/integration/test_num2pydate.py
+++ b/cf_units/tests/integration/test_num2pydate.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2021, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Test function :func:`cf_units.num2pydate`."""
 
 import unittest

--- a/cf_units/tests/integration/test_num2pydate.py
+++ b/cf_units/tests/integration/test_num2pydate.py
@@ -1,0 +1,41 @@
+# (C) British Crown Copyright 2021, Met Office
+#
+# This file is part of cf-units.
+#
+# cf-units is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cf-units is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+"""Test function :func:`cf_units.date2num`."""
+
+import unittest
+import datetime
+
+import numpy as np
+
+from cf_units import num2pydate
+
+
+class Test(unittest.TestCase):
+    def test_num2pydate_simple(self):
+        result = num2pydate(1, 'days since 1970-01-01', calendar='standard')
+        expected = datetime.datetime(1970, 1, 2)
+        self.assertEqual(result, expected)
+        self.assertIsInstance(result, datetime.datetime)
+
+    def test_num2pydate_wrong_calendar(self):
+        with self.assertRaisesRegex(ValueError,
+                                    'illegal calendar or reference date'):
+            num2pydate(1, 'days since 1970-01-01', calendar='360_day')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -964,6 +964,14 @@ class TestNumsAndDates(unittest.TestCase):
         self.assertEqual(str(res), "2010-11-02 13:00:00")
         self.assertIsInstance(res, datetime.datetime)
 
+    def test_num2date_wrong_calendar(self):
+        u = Unit('hours since 2010-11-02 12:00:00',
+                 calendar=unit.CALENDAR_360_DAY)
+        with self.assertRaisesRegex(ValueError,
+                                    'illegal calendar or reference date'):
+            u.num2date(1, only_use_cftime_datetimes=False,
+                       only_use_python_datetimes=True)
+
     def test_date2num(self):
         u = Unit(
             "hours since 2010-11-02 12:00:00", calendar=unit.CALENDAR_STANDARD

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -965,12 +965,17 @@ class TestNumsAndDates(unittest.TestCase):
         self.assertIsInstance(res, datetime.datetime)
 
     def test_num2date_wrong_calendar(self):
-        u = Unit('hours since 2010-11-02 12:00:00',
-                 calendar=unit.CALENDAR_360_DAY)
-        with self.assertRaisesRegex(ValueError,
-                                    'illegal calendar or reference date'):
-            u.num2date(1, only_use_cftime_datetimes=False,
-                       only_use_python_datetimes=True)
+        u = Unit(
+            "hours since 2010-11-02 12:00:00", calendar=unit.CALENDAR_360_DAY
+        )
+        with self.assertRaisesRegex(
+            ValueError, "illegal calendar or reference date"
+        ):
+            u.num2date(
+                1,
+                only_use_cftime_datetimes=False,
+                only_use_python_datetimes=True,
+            )
 
     def test_date2num(self):
         u = Unit(
@@ -980,18 +985,21 @@ class TestNumsAndDates(unittest.TestCase):
         self.assertEqual(str(u.num2date(u.date2num(d))), "2010-11-02 13:00:00")
 
     def test_num2pydate_simple(self):
-        u = Unit('hours since 2010-11-02 12:00:00',
-                 calendar=unit.CALENDAR_STANDARD)
+        u = Unit(
+            "hours since 2010-11-02 12:00:00", calendar=unit.CALENDAR_STANDARD
+        )
         result = u.num2pydate(1)
         expected = datetime.datetime(2010, 11, 2, 13)
         self.assertEqual(result, expected)
         self.assertIsInstance(result, datetime.datetime)
 
     def test_num2pydate_wrong_calendar(self):
-        u = Unit('hours since 2010-11-02 12:00:00',
-                 calendar=unit.CALENDAR_360_DAY)
-        with self.assertRaisesRegex(ValueError,
-                                    'illegal calendar or reference date'):
+        u = Unit(
+            "hours since 2010-11-02 12:00:00", calendar=unit.CALENDAR_360_DAY
+        )
+        with self.assertRaisesRegex(
+            ValueError, "illegal calendar or reference date"
+        ):
             u.num2pydate(1)
 
 

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -979,6 +979,21 @@ class TestNumsAndDates(unittest.TestCase):
         d = datetime.datetime(2010, 11, 2, 13, 0, 0)
         self.assertEqual(str(u.num2date(u.date2num(d))), "2010-11-02 13:00:00")
 
+    def test_num2pydate_simple(self):
+        u = Unit('hours since 2010-11-02 12:00:00',
+                 calendar=unit.CALENDAR_STANDARD)
+        result = u.num2pydate(1)
+        expected = datetime.datetime(2010, 11, 2, 13)
+        self.assertEqual(result, expected)
+        self.assertIsInstance(result, datetime.datetime)
+
+    def test_num2pydate_wrong_calendar(self):
+        u = Unit('hours since 2010-11-02 12:00:00',
+                 calendar=unit.CALENDAR_360_DAY)
+        with self.assertRaisesRegex(ValueError,
+                                    'illegal calendar or reference date'):
+            u.num2pydate(1)
+
 
 class Test_as_unit(unittest.TestCase):
     def test_already_unit(self):

--- a/doc/source/utilities.rst
+++ b/doc/source/utilities.rst
@@ -13,6 +13,7 @@ These are documented below.
 
 .. autofunction:: date2num
 .. autofunction:: num2date
+.. autofunction:: num2pydate
 
 .. autodata:: CALENDARS
 .. autodata:: CALENDAR_ALIASES


### PR DESCRIPTION
## 🚀 Pull Request

Hopefully a simple one!

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR exposes `cftime`'s `only_use_python_datetimes` keyword in our `num2date` function and method.  Also adds a convenience `num2pydate` function and method following [cftime's num2pydate](https://unidata.github.io/cftime/api.html#cftime.num2pydate).  This should make life easier for users who work exclusively with the standard calendar.

I couldn't find any existing tests for the `num2date` utility function, so added a new module.  I've kept the new tests pretty minimal as they are really just checking that the args have been passed correctly to the next function down.