### PR TITLE
Simple licence

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+How to contribute
+=================
+
+We want cf-units to be driven by the community - your contributions are
+invaluable to us! This page lists the guidelines for contributors which
+will help ease the process of getting your hard work accepted into cf-units,
+and shared back to the world.
+
+Getting started
+---------------
+
+1. If you've not already got one, sign up for a
+   [GitHub account](https://github.com/join).
+1. Fork the cf-units repository, create your new fix/feature branch, and
+   start committing code.
+1. Make sure you've added appropriate tests, and that *all* the tests
+   pass.
+
+Submitting changes
+------------------
+
+1. Read and sign the Contributor Licence Agreement (CLA).
+
+   See our [governance page](http://scitools.org.uk/governance.html) for the
+   CLA and what to do with it.
+1. Push your branch to your fork of cf-units.
+1. Submit your pull request.
+1. Chillax!
+
+If in doubt, please post in the
+[cf-units Discussions space](https://github.com/SciTools/cf-units/discussions) 
+and we'll be happy to help you.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ NOTE: This entire README can be markdown linted with
 - [Overview](#overview)
   - [Example](#example)
 - [Get in touch](#get-in-touch)
-- [License and copyright](#license-and-copyright)
+- [Credits, copyright and license](#credits--copyright-and-license)
 
 <!-- tocstop -->
 
@@ -75,17 +75,27 @@ Documentation can be found at <https://scitools.org.uk/cf-units/docs/latest/>.
 ## Get in touch
 
 - Questions, ideas, general discussion or announcements
-  of related projects use the
-  [Google Group](https://groups.google.com/forum/#!forum/scitools-iris).
-- Report bugs, suggest features or view the source code on
-  [GitHub](https://github.com/SciTools/cf-units).
+  of related projects: use the
+  [Discussions space](https://github.com/SciTools/cf-units/discussions).
+- Report bugs:
+  [submit a GitHub issue](https://github.com/SciTools/cf-units/issues)
+- Suggest features: see our [contributing guide](.github/CONTRIBUTING.md)
 
-## License and copyright
 
-cf-units is licensed under GNU Lesser General Public License (LGPLv3).
+## Credits, copyright and license
 
-Development occurs on GitHub at <https://github.com/SciTools/cf-units>, with a
-contributor's license agreement (CLA) that can be found at
-<https://scitools.org.uk/governance.html>.
+cf-units is developed collaboratively under the SciTools umberella.
 
-(C) British Crown Copyright, Met Office
+A full list of code contributors ("cf-units contributors") can be found at
+https://github.com/SciTools/cf-units/graphs/contributors.
+
+Code is just one of many ways of positively contributing to cf-units, please
+see our [contributing guide](.github/CONTRIBUTING.md) for more details on how
+you can get involved.
+
+cf-units is released under a LGPL license with a shared copyright model.
+See [COPYING](COPYING) and [COPYING.LESSER](COPYING.LESSER) for full terms.
+
+The [Met Office](https://metoffice.gov.uk) has made a significant
+contribution to the development, maintenance and support of this library.
+All Met Office contributions are copyright on behalf of the British Crown.

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ Documentation can be found at <https://scitools.org.uk/cf-units/docs/latest/>.
   of related projects: use the
   [Discussions space](https://github.com/SciTools/cf-units/discussions).
 - Report bugs:
-  [submit a GitHub issue](https://github.com/SciTools/cf-units/issues)
-- Suggest features: see our [contributing guide](.github/CONTRIBUTING.md)
+  [submit a GitHub issue](https://github.com/SciTools/cf-units/issues).
+- Suggest features: see our [contributing guide](.github/CONTRIBUTING.md).
 
 
 ## Credits, copyright and license
 
-cf-units is developed collaboratively under the SciTools umberella.
+cf-units is developed collaboratively under the SciTools umbrella.
 
 A full list of code contributors ("cf-units contributors") can be found at
 https://github.com/SciTools/cf-units/graphs/contributors.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ NOTE: This entire README can be markdown linted with
 - [Overview](#overview)
   - [Example](#example)
 - [Get in touch](#get-in-touch)
-- [Credits, copyright and license](#credits--copyright-and-license)
+- [Credits, copyright and license](#credits-copyright-and-license)
 
 <!-- tocstop -->
 

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2015 - 2021, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """
 Units of measure.
 

--- a/cf_units/_udunits2.pxd
+++ b/cf_units/_udunits2.pxd
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2016 - 2018, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 cdef extern from "udunits2.h":
     ctypedef struct ut_system:

--- a/cf_units/_udunits2.pyx
+++ b/cf_units/_udunits2.pyx
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2016 - 2018, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """
 Units of measure.
 
@@ -183,7 +172,7 @@ class UdunitsError(Exception):
         str_err = ': {}'.format(string.strerror(self.errnum)) \
                   if self.errnum else ''
         return '{}{}'.format(self.status_msg(), str_err)
-        
+
 
 def _raise_error():
     """

--- a/cf_units/_udunits2_parser/__init__.py
+++ b/cf_units/_udunits2_parser/__init__.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2019, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 import unicodedata
 

--- a/cf_units/_udunits2_parser/compile.py
+++ b/cf_units/_udunits2_parser/compile.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2015 - 2019, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 """
 Compiles the UDUNITS-2 grammar using ANTLR4.

--- a/cf_units/_udunits2_parser/graph.py
+++ b/cf_units/_udunits2_parser/graph.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2019, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 
 class Node:

--- a/cf_units/config.py
+++ b/cf_units/config.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2010 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 
 import configparser

--- a/cf_units/tests/__init__.py
+++ b/cf_units/tests/__init__.py
@@ -1,16 +1,5 @@
-# (C) British Crown Copyright 2010 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.

--- a/cf_units/tests/integration/__init__.py
+++ b/cf_units/tests/integration/__init__.py
@@ -1,16 +1,5 @@
-# (C) British Crown Copyright 2016 - 2018, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.

--- a/cf_units/tests/integration/parse/test_graph.py
+++ b/cf_units/tests/integration/parse/test_graph.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2019, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 from cf_units._udunits2_parser import parse
 import cf_units._udunits2_parser.graph as g

--- a/cf_units/tests/integration/parse/test_parse.py
+++ b/cf_units/tests/integration/parse/test_parse.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2019, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 import re
 

--- a/cf_units/tests/integration/test__num2date_to_nearest_second.py
+++ b/cf_units/tests/integration/test__num2date_to_nearest_second.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2016 - 2021, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Test function :func:`cf_units._num2date_to_nearest_second`."""
 
 import unittest

--- a/cf_units/tests/integration/test_date2num.py
+++ b/cf_units/tests/integration/test_date2num.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2016 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Test function :func:`cf_units.date2num`."""
 
 import unittest

--- a/cf_units/tests/test_coding_standards.py
+++ b/cf_units/tests/test_coding_standards.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2013 - 2021, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 from datetime import datetime
 from fnmatch import fnmatch
@@ -28,28 +17,11 @@ import cf_units
 
 
 LICENSE_TEMPLATE = """
-# (C) British Crown Copyright {YEARS}, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.""".strip()
-
-
-LICENSE_RE_PATTERN = re.escape(LICENSE_TEMPLATE).replace(r'\{YEARS\}', '(.*?)')
-SHEBANG = r'(\#\!.*\n)?'
-ENCODING = r'(\# \-\*\- coding\: .* \-\*\-\n)?'
-LICENSE_RE = re.compile(SHEBANG + ENCODING + LICENSE_RE_PATTERN, re.MULTILINE)
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details."""
 
 
 # Guess cf_units repo directory of cf_units - realpath is used to mitigate
@@ -65,32 +37,6 @@ DOCS_DIRS = [DOC_DIR for DOC_DIR in DOCS_DIRS if os.path.basename(DOC_DIR) not
 
 
 class TestLicenseHeaders(unittest.TestCase):
-    @staticmethod
-    def years_of_license_in_file(fh):
-        """
-        Using :data:`LICENSE_RE` look for the years defined in the license
-        header of the given file handle.
-
-        If the license cannot be found in the given fh, None will be returned,
-        else a tuple of (start_year, end_year) will be returned.
-
-        """
-        license_matches = LICENSE_RE.match(fh.read())
-        if not license_matches:
-            # no license found in file.
-            return None
-
-        years = license_matches.groups()[-1]
-        if len(years) == 4:
-            start_year = end_year = int(years)
-        elif len(years) == 11:
-            start_year, end_year = int(years[:4]), int(years[7:])
-        else:
-            fname = getattr(fh, 'name', 'unknown filename')
-            raise ValueError("Unexpected year(s) string in {}'s copyright "
-                             "notice: {!r}".format(fname, years))
-        return (start_year, end_year)
-
     @staticmethod
     def whatchanged_parse(whatchanged_output):
         """
@@ -168,18 +114,12 @@ class TestLicenseHeaders(unittest.TestCase):
             if full_fname.endswith('.py') and os.path.isfile(full_fname) and \
                     not any(fnmatch(fname, pat) for pat in exclude_patterns):
                 with open(full_fname) as fh:
-                    years = TestLicenseHeaders.years_of_license_in_file(fh)
-                    if years is None:
-                        print('The file {} has no valid header license and '
-                              'has not been excluded from the license header '
-                              'test.'.format(fname))
-                        failed = True
-                    elif last_change.year > years[1]:
-                        print('The file header at {} is out of date. The last'
-                              ' commit was in {}, but the copyright states it'
-                              ' was {}.'.format(fname, last_change.year,
-                                                years[1]))
-                        failed = True
+                    content = fh.read()
+                    if not content.startswith(LICENSE_TEMPLATE):
+                        print(
+                            f'The file {fname} does not start with the '
+                            f'required license header.'
+                        )
 
         if failed:
             raise AssertionError(

--- a/cf_units/tests/test_tex.py
+++ b/cf_units/tests/test_tex.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2019 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 import pytest
 

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -1,20 +1,9 @@
 # -*- coding: utf-8 -*-
-# (C) British Crown Copyright 2010 - 2021, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """
 Test Unit the wrapper class for Unidata udunits2.
 

--- a/cf_units/tests/unit/__init__.py
+++ b/cf_units/tests/unit/__init__.py
@@ -1,17 +1,6 @@
-# (C) British Crown Copyright 2013 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Unit tests for the :mod:`cf_units` package."""

--- a/cf_units/tests/unit/test__udunits2.py
+++ b/cf_units/tests/unit/test__udunits2.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2017 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Unit tests for the `cf_units._udunits2` module.
 
 In most cases, we don't test the correctness

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2015 - 2021, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Unit tests for the `cf_units.Unit` class."""
 
 import unittest

--- a/cf_units/tests/unit/unit/test_as_unit.py
+++ b/cf_units/tests/unit/unit/test_as_unit.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2016 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """Unit tests for the `cf_units.as_unit` function."""
 
 import copy

--- a/cf_units/tex.py
+++ b/cf_units/tex.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2019 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 import cf_units._udunits2_parser.graph as graph  # noqa: E402
 from cf_units._udunits2_parser import parse as _parse  # noqa: E402

--- a/cf_units/util.py
+++ b/cf_units/util.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2010 - 2020, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 """
 Miscellaneous utility functions.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2016 - 2018, Met Office
+# Copyright cf-units contributors
 #
-# This file is part of cf-units.
-#
-# cf-units is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cf-units is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cf-units.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 # -*- coding: utf-8 -*-
 #
@@ -48,7 +37,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 project = u'cf-units'
-copyright = 'British Crown Copyright 2015 - 2018, Met Office'
+copyright = 'Copyright cf-units contributors'
 
 
 current_version = cf_units.__version__


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Another item from #171.

In line with the latest [SciTools licensing guidelines](https://github.com/SciTools/scitools.org.uk/blob/master/documents/scitools_licensing.md#source-preamble):

* The licence headers are much shorter and mostly reference the main licensing files in the root directory.
  The years test in `test_coding_standards.py` has been replaced with a basic check that each file starts with the correct string.
* `README.md` aligns with the example in the guidelines.
* A `CONTRIBUTING.md` has been added, as this is referenced by the updated `README.md`.