### PR TITLE
license headers follow up

### DIFF
--- a/cf_units/tests/test_coding_standards.py
+++ b/cf_units/tests/test_coding_standards.py
@@ -16,8 +16,7 @@ import unittest
 import cf_units
 
 
-LICENSE_TEMPLATE = """
-# Copyright cf-units contributors
+LICENSE_TEMPLATE = """# Copyright cf-units contributors
 #
 # This file is part of cf-units and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
@@ -120,6 +119,7 @@ class TestLicenseHeaders(unittest.TestCase):
                             f'The file {fname} does not start with the '
                             f'required license header.'
                         )
+                        failed = True
 
         if failed:
             raise AssertionError(

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright cf-units contributors
 #
 # This file is part of cf-units and is released under the LGPL license.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
There was a small omission in the license header test change at #177, so it couldn't produce a test failure.  I blame the reviewer.

Test failed for all files because of the initial new line in the template.  The `# -*- coding: utf-8 -*-` also caused a failure, but that was only needed at python 2 anyway.