### PR TITLE
Persist calendar when discarding cftime microsecond

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -403,23 +403,14 @@ def _discard_microsecond(date):
         datetime, or numpy.ndarray of datetime object.
 
     """
-    dates = np.asarray(date)
+    dates = np.asanyarray(date)
     shape = dates.shape
     dates = dates.ravel()
-    result = None
-    # Create date objects of the same type returned by cftime.num2date()
-    # (either datetime.datetime or cftime.datetime), discarding the
-    # microseconds
-    discard = [dt.replace(microsecond=0) for dt in dates if dt]
-    if discard:
-        dates = np.array(discard)
-        if shape == ():
-            result = dates[0]
-        else:
-            if np.prod(shape) == dates.size:
-                result = dates.reshape(shape)
-            else:
-                result = dates
+
+    # using the "and" pattern to support masked arrays of datetimes
+    dates = np.array([dt and dt.replace(microsecond=0) for dt in dates])
+    result = dates[0] if shape == () else dates.reshape(shape)
+
     return result
 
 

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -410,20 +410,7 @@ def _discard_microsecond(date):
     # Create date objects of the same type returned by cftime.num2date()
     # (either datetime.datetime or cftime.datetime), discarding the
     # microseconds
-    discard = []
-    for dt in dates:
-        if dt:
-            kwargs = dict(
-                year=dt.year,
-                month=dt.month,
-                day=dt.day,
-                hour=dt.hour,
-                minute=dt.minute,
-                second=dt.second,
-            )
-            if isinstance(dt, cftime.datetime):
-                kwargs["calendar"] = dt.calendar
-            discard.append(dt.__class__(**kwargs))
+    discard = [dt.replace(microsecond=0) for dt in dates if dt]
     if discard:
         dates = np.array(discard)
         if shape == ():

--- a/cf_units/tests/unit/test__discard_microsecond.py
+++ b/cf_units/tests/unit/test__discard_microsecond.py
@@ -1,0 +1,109 @@
+# Copyright cf-units contributors
+#
+# This file is part of cf-units and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Unit tests for the `cf_units._discard_microsecond` function."""
+
+import datetime
+import unittest
+
+import cftime
+import numpy as np
+
+from cf_units import _discard_microsecond as discard_microsecond
+
+
+class Test__datetime(unittest.TestCase):
+    def setUp(self):
+        self.kwargs = dict(year=1, month=2, day=3, hour=4, minute=5, second=6)
+        self.expected = datetime.datetime(**self.kwargs, microsecond=0)
+
+    def test_single(self):
+        dt = datetime.datetime(**self.kwargs, microsecond=7)
+        actual = discard_microsecond(dt)
+        self.assertEqual(self.expected, actual)
+
+    def test_multi(self):
+        shape = (5, 2)
+        n = np.prod(shape)
+
+        dates = np.array(
+            [datetime.datetime(**self.kwargs, microsecond=i) for i in range(n)]
+        ).reshape(shape)
+        actual = discard_microsecond(dates)
+        expected = np.array([self.expected] * n).reshape(shape)
+        np.testing.assert_array_equal(expected, actual)
+
+
+class Test__cftime(unittest.TestCase):
+    def setUp(self):
+        self.kwargs = dict(year=1, month=2, day=3, hour=4, minute=5, second=6)
+        self.calendars = cftime._cftime._calendars
+
+    def test_single(self):
+        for calendar in self.calendars:
+            dt = cftime.datetime(**self.kwargs, calendar=calendar)
+            actual = discard_microsecond(dt)
+            expected = cftime.datetime(
+                **self.kwargs, microsecond=0, calendar=calendar
+            )
+            self.assertEqual(expected, actual)
+
+    def test_multi(self):
+        shape = (2, 5)
+        n = np.prod(shape)
+
+        for calendar in self.calendars:
+            dates = np.array(
+                [
+                    cftime.datetime(**self.kwargs, calendar=calendar)
+                    for i in range(n)
+                ]
+            ).reshape(shape)
+            actual = discard_microsecond(dates)
+            expected = np.array(
+                [
+                    cftime.datetime(
+                        **self.kwargs, microsecond=0, calendar=calendar
+                    )
+                ]
+                * n
+            ).reshape(shape)
+            np.testing.assert_array_equal(expected, actual)
+
+
+class Test__falsy(unittest.TestCase):
+    def setUp(self):
+        kwargs = dict(year=1, month=2, day=3, hour=4, minute=5, second=6)
+        self.cftime = cftime.datetime(
+            **kwargs, microsecond=0, calendar="gregorian"
+        )
+        self.datetime = datetime.datetime(**kwargs, microsecond=0)
+
+    def test_single__none(self):
+        self.assertIsNone(discard_microsecond(None))
+
+    def test_single__false(self):
+        self.assertIsNone(discard_microsecond(False))
+
+    def test_multi__falsy(self):
+        self.assertIsNone(discard_microsecond([None, False, 0]))
+
+    def test_multi__mixed(self):
+        dates = [None, self.cftime, False, self.datetime]
+        actual = discard_microsecond(dates)
+        expected = np.array([self.cftime, self.datetime])
+        np.testing.assert_array_equal(expected, actual)
+
+    def test_multi__mixed_ravel(self):
+        dates = np.array([None, self.cftime, False, self.datetime]).reshape(
+            2, 2
+        )
+        actual = discard_microsecond(dates)
+        expected = np.array([self.cftime, self.datetime])
+        np.testing.assert_array_equal(expected, actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -67,7 +67,7 @@ class Test_convert__calendar(unittest.TestCase):
             (np.float64, True),
             (np.int32, False),
             (np.int64, False),
-            (np.int, False),
+            (int, False),
         ):
             data = np.arange(4, dtype=start_dtype)
             u1 = Unit("hours since 2000-01-01 00:00:00", calendar="360_day")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ exclude = '''
     | build
     | dist
   )/
+  | _version.py
 )
 '''
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR addresses issues discovered whilst testing [SciTools/iris](https://github.com/SciTools/iris) when attempting to unpin `cftime`, whereby the specific `calendar` of `cftime.datetime` objects are not persisted whenever the `cf_units._discard_microsecond` function was called.

Once this PR is merged, I'd like to cut a `cf-units` 3.0.1 patch release to support an `iris` 3.0.3 patch release.