### PR TITLE
add udunits xml to wheel

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ env:
 #
 # Linting
 #
-lint_task:
+task:
   auto_cancellation: true
   container:
     image: python:latest
@@ -44,7 +44,7 @@ lint_task:
 #
 # Testing (Linux)
 #
-linux_task:
+task:
   auto_cancellation: true
   matrix:
     env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include cf_units/etc/site.cfg.template
 include CHANGES COPYING COPYING.LESSER INSTALL
 exclude cf_units/etc/site.cfg
 graft requirements
+prune .github

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+ignore:
+  - cf_units/_version.py
+  - cf_units/config.py
 coverage:
   status:
     project:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ exclude = '''
     | build
     | dist
   )/
+  | _version.py
 )
 '''
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def get_library_dirs():
 def get_package_data():
     package_data = None
     # Determine whether we're building a wheel.
-    if environ.get("CFUNITS_WHEEL") is not None:
+    if "bdist_wheel" in sys.argv:
         # The protocol is that the UDUNITS2_XML_PATH environment variable
         # identifies the root UDUNITS2 XML file and parent directory containing
         # all the XML resource files that require to be bundled within this

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import sys
 from distutils.sysconfig import get_config_var
 from os import environ
 from pathlib import Path
+from shutil import copy
 
 from setuptools import Command, Extension, setup
 
@@ -14,8 +15,9 @@ except ImportError:
 COMPILER_DIRECTIVES = {}
 DEFINE_MACROS = None
 FLAG_COVERAGE = "--cython-coverage"  # custom flag enabling Cython line tracing
-BASEDIR = Path(__file__).parent.absolute()
-CFUNITS_DIR = BASEDIR / "cf_units"
+BASEDIR = Path(__file__).resolve().parent
+PACKAGE = "cf_units"
+CFUNITS_DIR = BASEDIR / PACKAGE
 
 
 class CleanCython(Command):
@@ -37,24 +39,62 @@ class CleanCython(Command):
             print(message)
 
 
-include_dir = get_config_var("INCLUDEDIR")
-include_dirs = [include_dir] if include_dir is not None else []
-library_dir = get_config_var("LIBDIR")
-library_dirs = [library_dir] if library_dir is not None else []
+def get_include_dirs():
+    include_dirs = []
+    include_dir = environ.get("UDUNITS2_INCDIR")
+    if include_dir is None:
+        include_dir = get_config_var("INCLUDEDIR")
+    if include_dir is not None:
+        include_dirs.append(include_dir)
+    return include_dirs
 
-if sys.platform.startswith("win"):
-    extra_extension_args = {}
-else:
-    extra_extension_args = dict(runtime_library_dirs=library_dirs)
 
-ext = "pyx" if cythonize else "c"
+def get_library_dirs():
+    library_dirs = []
+    library_dir = environ.get("UDUNITS2_LIBDIR")
+    if library_dir is None:
+        library_dir = get_config_var("LIBDIR")
+    if library_dir is not None:
+        library_dirs.append(library_dir)
+    return library_dirs
 
-if FLAG_COVERAGE in sys.argv or environ.get("CYTHON_COVERAGE", None):
-    COMPILER_DIRECTIVES = {"linetrace": True}
-    DEFINE_MACROS = [("CYTHON_TRACE", "1"), ("CYTHON_TRACE_NOGIL", "1")]
-    if FLAG_COVERAGE in sys.argv:
-        sys.argv.remove(FLAG_COVERAGE)
-    print('enable: "linetrace" Cython compiler directive')
+
+def get_package_data():
+    package_data = None
+    # Determine whether we're building a wheel.
+    if environ.get("CFUNITS_WHEEL") is not None:
+        # The protocol is that the UDUNITS2_XML_PATH environment variable
+        # identifies the root UDUNITS2 XML file and parent directory containing
+        # all the XML resource files that require to be bundled within this
+        # wheel. Note that, this should match the UDUNITS2 distribution for the
+        # UDUNITS2 library cf-units is linking against.
+        xml_env = "UDUNITS2_XML_PATH"
+        xml_database = environ.get(xml_env)
+        if xml_database is None:
+            emsg = f"Require to set {xml_env} for a cf-units wheel build."
+            raise ValueError(emsg)
+        xml_database = Path(xml_database)
+        if not xml_database.is_file():
+            emsg = (
+                f"Can't open {xml_env} file {xml_database} "
+                "during cf-units wheel build."
+            )
+            raise ValueError(emsg)
+        # We have a valid XML file, so copy the distro bundle into the
+        # cf_units/etc/share directory.
+        xml_dir = xml_database.expanduser().resolve().parent
+        share_base = Path("etc") / "share"
+        share_dir = CFUNITS_DIR / share_base
+        if not share_dir.is_dir():
+            share_dir.mkdir(parents=True)
+        else:
+            # Purge any existing XML share files.
+            [fname.unlink() for fname in share_dir.glob("*.xml")]
+        # Bundle the UDUNITS2 XML file/s for the wheel.
+        [copy(fname, share_dir) for fname in xml_dir.glob("*.xml")]
+        # Register our additional wheel content.
+        package_data = {PACKAGE: [str(share_base / "*.xml")]}
+    return package_data
 
 
 def numpy_build_ext(pars):
@@ -78,14 +118,25 @@ def numpy_build_ext(pars):
     return build_ext(pars)
 
 
+if FLAG_COVERAGE in sys.argv or environ.get("CYTHON_COVERAGE", None):
+    COMPILER_DIRECTIVES = {"linetrace": True}
+    DEFINE_MACROS = [("CYTHON_TRACE", "1"), ("CYTHON_TRACE_NOGIL", "1")]
+    if FLAG_COVERAGE in sys.argv:
+        sys.argv.remove(FLAG_COVERAGE)
+    print('enable: "linetrace" Cython compiler directive')
+
+library_dirs = get_library_dirs()
+
 udunits_ext = Extension(
-    "cf_units._udunits2",
-    ["cf_units/_udunits2.{}".format(ext)],
-    include_dirs=include_dirs,
+    f"{PACKAGE}._udunits2",
+    [str(Path(f"{PACKAGE}") / f"_udunits2.{'pyx' if cythonize else 'c'}")],
+    include_dirs=get_include_dirs(),
     library_dirs=library_dirs,
     libraries=["udunits2"],
     define_macros=DEFINE_MACROS,
-    **extra_extension_args,
+    runtime_library_dirs=None
+    if sys.platform.startswith("win")
+    else library_dirs,
 )
 
 if cythonize:
@@ -98,6 +149,7 @@ cmdclass = {"clean_cython": CleanCython, "build_ext": numpy_build_ext}
 kwargs = dict(
     cmdclass=cmdclass,
     ext_modules=[udunits_ext],
+    package_data=get_package_data(),
 )
 
 setup(**kwargs)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR supports #186, by injecting the associated UDUNITS2 xml files into a wheel build of `cf-units`.

@ocefpaf To build in a `quay.io/pypa/manylinux2014_x86_64` docker container, I had to do the following:
```
yum install -y udunits2-devel

export UDUNITS2_INCDIR="/usr/include/udunits2"
export UDUNITS2_LIBDIR="/usr/lib64"
export UDUNITS2_XML_PATH="/usr/share/udunits/udunits2.xml"

export PYBIN="/opt/python/cp38-cp38/bin/python"

$PYBIN -m pip install --upgrade pip wheel setuptools setuptools_scm build twine
$PYBIN -m build --sdist --wheel . --outdir /io/wheelhouse/

auditwheel repair /io/wheelhouse/*.whl

```

Note that, the UDUNITS2 XML files populate the `etc/share` directory only for a `bdist_wheel` and not a `sdist`.

When a wheel installed `cf-units` distro executes it auto-generates an ephemeral `site.cfg` pointing to the bundled XML files, and the rest of the machinery works as normal. The wheel should be consistent with regards to `udunits2`, as the wheel bundles the `udunits2` dynamic library associated with the `etc/share` XML files