### PR TITLE
update gh action pypi-publish version

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -34,7 +34,7 @@ jobs:
         python -m twine check *
 
     - name: Publish a Python distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1.4.2
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR follows-up on #186 by pinning to an explicit stable release version for the gh-action `pypi-publish`.
