### PR TITLE
fix gh action version

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -34,7 +34,7 @@ jobs:
         python -m twine check *
 
     - name: Publish a Python distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1.4.2
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
## 🚀 Pull Request

### Description
The `pypa/gh-action-pypi-publish` suggests the [syntax](https://github.com/pypa/gh-action-pypi-publish#usage) for the GH action version, but clearly this isn't the case.

Trying again...
