### PR TITLE
Support gregorian to standard calendar change

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -130,7 +130,7 @@ CALENDARS = [
 #: Where calendars have multiple names, we map the alias to the
 #: definitive form.
 CALENDAR_ALIASES = {
-    CALENDAR_STANDARD: CALENDAR_GREGORIAN,
+    CALENDAR_GREGORIAN: CALENDAR_STANDARD,
     CALENDAR_NO_LEAP: CALENDAR_365_DAY,
     CALENDAR_ALL_LEAP: CALENDAR_366_DAY,
 }
@@ -830,7 +830,7 @@ class Unit(_OrderedHashable):
                 raise value_error from None
             if _OP_SINCE in unit.lower():
                 if calendar is None:
-                    calendar_ = CALENDAR_GREGORIAN
+                    calendar_ = CALENDAR_STANDARD
                 elif isinstance(calendar, (str,)):
                     calendar_ = calendar.lower()
                     if calendar_ in CALENDAR_ALIASES:
@@ -1815,7 +1815,7 @@ class Unit(_OrderedHashable):
             # gregorian calendar as it handles these and udunits does not.
             if (
                 self.is_time_reference()
-                and self.calendar != CALENDAR_GREGORIAN
+                and self.calendar != CALENDAR_STANDARD
             ):
                 result_datetimes = cftime.num2date(
                     result, self.cftime_unit, self.calendar

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1813,10 +1813,7 @@ class Unit(_OrderedHashable):
                 result = copy.deepcopy(value)
             # Use cftime for converting reference times that are not using a
             # gregorian calendar as it handles these and udunits does not.
-            if (
-                self.is_time_reference()
-                and self.calendar != CALENDAR_STANDARD
-            ):
+            if self.is_time_reference() and self.calendar != CALENDAR_STANDARD:
                 result_datetimes = cftime.num2date(
                     result, self.cftime_unit, self.calendar
                 )

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -47,7 +47,7 @@ class Test_unit__creation(unittest.TestCase):
 
     def test_no_calendar(self):
         u = Unit("hours since 1970-01-01 00:00:00")
-        self.assertEqual(u.calendar, unit.CALENDAR_GREGORIAN)
+        self.assertEqual(u.calendar, unit.CALENDAR_STANDARD)
 
     def test_unsupported_calendar(self):
         with self.assertRaisesRegex(ValueError, "unsupported calendar"):
@@ -576,9 +576,9 @@ class Test_stringify(unittest.TestCase):
 
     def test___repr___time_unit(self):
         u = Unit(
-            "hours since 2007-01-15 12:06:00", calendar=unit.CALENDAR_STANDARD
+            "hours since 2007-01-15 12:06:00", calendar=unit.CALENDAR_GREGORIAN
         )
-        exp = "Unit('hours since 2007-01-15 12:06:00', calendar='gregorian')"
+        exp = "Unit('hours since 2007-01-15 12:06:00', calendar='standard')"
         self.assertEqual(repr(u), exp)
 
 
@@ -949,11 +949,11 @@ class TestTimeEncoding(unittest.TestCase):
 class TestNumsAndDates(unittest.TestCase):
     def test_num2date(self):
         u = Unit(
-            "hours since 2010-11-02 12:00:00", calendar=unit.CALENDAR_STANDARD
+            "hours since 2010-11-02 12:00:00", calendar=unit.CALENDAR_GREGORIAN
         )
         res = u.num2date(1)
         self.assertEqual(str(res), "2010-11-02 13:00:00")
-        self.assertEqual(res.calendar, "gregorian")
+        self.assertEqual(res.calendar, "standard")
         self.assertIsInstance(res, cftime.datetime)
 
     def test_num2date_py_datetime_type(self):

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -15,8 +15,8 @@ from cf_units import Unit
 
 class Test___init__(unittest.TestCase):
     def test_capitalised_calendar(self):
-        calendar = "GrEgoRian"
-        expected = cf_units.CALENDAR_GREGORIAN
+        calendar = "StAnDaRd"
+        expected = cf_units.CALENDAR_STANDARD
         u = Unit("hours since 1970-01-01 00:00:00", calendar=calendar)
         self.assertEqual(u.calendar, expected)
 

--- a/cf_units/tests/unit/unit/test_as_unit.py
+++ b/cf_units/tests/unit/unit/test_as_unit.py
@@ -46,11 +46,11 @@ class TestAll(unittest.TestCase):
     def test_non_cf_unit_no_calendar(self):
         # On passing as_unit a cf_unit.Unit-like object (not a cf_unit.Unit
         # object) with no calendar, ensure that a cf_unit.Unit is returned
-        # with default calendar (Gregorian).
+        # with default calendar (standard).
         unit = StubUnit()
         result = as_unit(unit)
 
-        self.assertEqual(result.calendar, "gregorian")
+        self.assertEqual(result.calendar, "standard")
         self.assertIsInstance(result, Unit)
 
     def test_non_cf_unit_with_calendar(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Change definitive form of calendar from `gregorian` to `standard`, instead of the other way around. 
With first time attempt at [change of ] unit tests for this.