### PR TITLE
Make mamba overwrite the existing lockfile on cache miss

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -79,7 +79,7 @@ task:
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
     populate_script:
       - conda-lock --mamba --platform linux-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
-      - mamba create --name py${PY_VER} --quiet --file conda-linux-64.lock
+      - mamba create --name py${PY_VER} --quiet --file conda-linux-64.lock --yes
       - cp conda-linux-64.lock ${HOME}/mambaforge/envs/py${PY_VER}
   test_script:
     - cat ${HOME}/mambaforge/envs/py${PY_VER}/conda-linux-64.lock >&2


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Adding --yes option to `mamba create` command in the cirrus ci config so that it can overwrite an existing lockfile if the cache missed