### PR TITLE
PoC fix issue 216

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -20,6 +20,9 @@ from contextlib import contextmanager
 import cftime
 import numpy as np
 
+# low level cftime function for checking date part of unit string in Unit
+from cftime._cftime import _dateparse as _time_unit_parse_date
+
 from cf_units import _udunits2 as _ud
 from cf_units._udunits2 import (
     UT_ASCII,
@@ -789,6 +792,7 @@ class Unit(_OrderedHashable):
             >>> unknown = Unit(None)
 
         """
+
         ut_unit = _ud.NULL_UNIT
         calendar_ = None
 
@@ -838,6 +842,14 @@ class Unit(_OrderedHashable):
                     if calendar_ not in CALENDARS:
                         msg = "{!r} is an unsupported calendar."
                         raise ValueError(msg.format(calendar))
+                    else:
+                        # check date/time point for valid origin:
+                        print(unit)
+                        print(calendar)
+                        try:
+                            _ = _time_unit_parse_date(unit, calendar_)
+                        except TypeError:
+                            raise ValueError("Cannot parse the time unit")
                 else:
                     msg = "Expected string-like calendar argument, got {!r}."
                     raise TypeError(msg.format(type(calendar)))

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -844,12 +844,17 @@ class Unit(_OrderedHashable):
                         raise ValueError(msg.format(calendar))
                     else:
                         # check date/time point for valid origin:
-                        print(unit)
-                        print(calendar)
                         try:
-                            _ = _time_unit_parse_date(unit, calendar_)
-                        except TypeError:
-                            raise ValueError("Cannot parse the time unit")
+                            origin = _time_unit_parse_date(unit, calendar_)
+                            if origin.year <= 0 and calendar_ in {
+                                CALENDAR_STANDARD,
+                                CALENDAR_JULIAN,
+                            }:
+                                raise ValueError(
+                                    "Year <= 0 should raise a warning or an error"
+                                )
+                        except (TypeError, ValueError) as e:
+                            raise ValueError(str(e))
                 else:
                     msg = "Expected string-like calendar argument, got {!r}."
                     raise TypeError(msg.format(type(calendar)))

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -53,12 +53,58 @@ class Test_unit__creation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unsupported calendar"):
             Unit("hours since 1970-01-01 00:00:00", calendar="wibble")
 
-    def test_calendar_w_unicode(self):
-        calendar = unit.CALENDAR_365_DAY
-        u = Unit("hours\xb2 hours-1 since epoch", calendar=calendar)
-        self.assertEqual(u.calendar, calendar)
-        expected = "hours² hours-1 since 1970-01-01 00:00:00"
-        self.assertEqual(u.origin, expected)
+    # ####
+    def test_malformed_monthday_in_time_unit(self):
+        with self.assertRaisesRegex(ValueError, "Failed to parse unit"):
+            Unit("hours since 1970-0101 00:00:00", calendar="standard")
+
+    def test_illegal_string_in_time_unit(self):
+        with self.assertRaisesRegex(ValueError, "Failed to parse unit"):
+            Unit("hours since haywire", calendar="proleptic_gregorian")
+
+    def test_illegal_month0_in_time_unit(self):
+        with self.assertRaisesRegex(ValueError, "Illegal date/time in unit"):
+            Unit("days since 1970-0-1 00:00:00", calendar="standard")
+
+    def test_illegal_month13_in_time_unit(self):
+        with self.assertRaisesRegex(ValueError, "Illegal date/time in unit"):
+            Unit("days since 1970-13-01", calendar="standard")
+
+    def test_illegal_day0_in_time_unit(self):
+        with self.assertRaisesRegex(ValueError, "Failed date/time in unit"):
+            Unit("days since 1970-01-0", calendar="julian")
+
+    def test_illegal_leap_day_in_time_unit(self):
+        with self.assertRaisesRegex(ValueError, "Illegal date/time in unit"):
+            Unit("days since 1971-2-29", calendar="standard")
+
+    def test_illegal_hour_in_time_unit(self):
+        with self.assertRaisesRegex(ValueError, "Illegal date/time in unit"):
+            Unit("days since 1971-2-28 24:00:00", calendar="standard")
+
+    def test_standard_year0_in_time_unit(self):
+        with self.assertRaisesRegex(
+            ValueError, "Year <= 0 should raise a warning or an error"
+        ):
+            Unit("days since 0-1-1 0:0:0", calendar="standard")
+
+    def test_julian_year0_in_time_unit(self):
+        with self.assertRaisesRegex(
+            ValueError, "Year <= 0 should raise a warning or an error"
+        ):
+            Unit("days since 0-1-1 0:0:0", calendar="julian")
+
+    def test_standard_negative_year_in_time_unit(self):
+        with self.assertRaisesRegex(
+            ValueError, "Year <= 0 should raise a warning or an error"
+        ):
+            Unit("days since -1-1-1 0:0:0", calendar="standard")
+
+    def test_julian_negative_year_in_time_unit(self):
+        with self.assertRaisesRegex(
+            ValueError, "Year <= 0 should raise a warning or an error"
+        ):
+            Unit("days since -10-1-1", calendar="julian")
 
     def test_unicode_valid(self):
         # Some unicode characters are allowed.


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Added "parser" to check validity of date/time part of time unit string. The "parser" is in fact a low level private function from `cftime`. Whether this is appropriate I am not sure, but implementing the same functionality more or less from scratch is beyond my capacity. [Hence the "PoC"]. 

From the added unit tests it *seems* -- in principle -- that the examples in #216 are handled. Only "in principle" because the actual errors generated by the cftime function are not properly captured. But again, understanding how cython exceptions interact with pytest is too advanced for me.


