### PR TITLE
Implement Unit.change_calendar

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1746,6 +1746,31 @@ class Unit(_OrderedHashable):
         """
         return not self == other
 
+    def change_calendar(self, calendar):
+        """
+        Returns a new unit with the requested calendar, modifying the reference
+        date if necessary.  Only works with calenders that represent the real
+        world (standard, proleptic_gregorian, julian) and with short time
+        intervals (days or less).
+
+        For example:
+
+            >>> from cf_units import Unit
+            >>> u = Unit('days since 1500-01-01', calendar='proleptic_gregorian')
+            >>> u.change_calendar('standard')
+            Unit('days since 1499-12-23T00:00:00', calendar='standard')
+
+        """
+        if not self.is_time_reference():
+            raise ValueError("unit is not a time reference")
+
+        ref_date = self.num2date(0)
+        new_ref_date = ref_date.change_calendar(calendar)
+        time_units = self.origin.split(_OP_SINCE)[0]
+        new_origin = _OP_SINCE.join([time_units, new_ref_date.isoformat()])
+
+        return Unit(new_origin, calendar=calendar)
+
     def convert(self, value, other, ctype=FLOAT64, inplace=False):
         """
         Converts a single value or NumPy array of values from the current unit

--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -1749,7 +1749,7 @@ class Unit(_OrderedHashable):
     def change_calendar(self, calendar):
         """
         Returns a new unit with the requested calendar, modifying the reference
-        date if necessary.  Only works with calenders that represent the real
+        date if necessary.  Only works with calendars that represent the real
         world (standard, proleptic_gregorian, julian) and with short time
         intervals (days or less).
 

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -31,6 +31,51 @@ class Test___init__(unittest.TestCase):
         self.assertEqual(u, expected)
 
 
+class Test_change_calendar(unittest.TestCase):
+    def test_modern_standard_to_proleptic_gregorian(self):
+        u = Unit("hours since 1970-01-01 00:00:00", calendar="standard")
+        expected = Unit(
+            "hours since 1970-01-01 00:00:00", calendar="proleptic_gregorian"
+        )
+        result = u.change_calendar("proleptic_gregorian")
+        self.assertEqual(result, expected)
+
+    def test_ancient_standard_to_proleptic_gregorian(self):
+        u = Unit("hours since 1500-01-01 00:00:00", calendar="standard")
+        expected = Unit(
+            "hours since 1500-01-10 00:00:00", calendar="proleptic_gregorian"
+        )
+        result = u.change_calendar("proleptic_gregorian")
+        self.assertEqual(result, expected)
+
+    def test_no_change(self):
+        u = Unit("hours since 1500-01-01 00:00:00", calendar="standard")
+        result = u.change_calendar("standard")
+        self.assertEqual(result, u)
+        # Docstring states that a new unit is returned, so check these are not
+        # the same object.
+        self.assertIsNot(result, u)
+
+    def test_long_time_interval(self):
+        u = Unit("months since 1970-01-01", calendar="standard")
+        with self.assertRaisesRegex(ValueError, "cannot be processed"):
+            u.change_calendar("proleptic_gregorian")
+
+    def test_wrong_calendar(self):
+        u = Unit("days since 1900-01-01", calendar="360_day")
+        with self.assertRaisesRegex(
+            ValueError, "change_calendar only works for real-world calendars"
+        ):
+            u.change_calendar("standard")
+
+    def test_non_time_unit(self):
+        u = Unit("m")
+        with self.assertRaisesRegex(
+            ValueError, "unit is not a time reference"
+        ):
+            u.change_calendar("standard")
+
+
 class Test_convert__calendar(unittest.TestCase):
     class MyStr(str):
         pass


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Inspired by https://github.com/SciTools/cf-units/issues/185#issuecomment-1051031393, introduce a method to replace a unit's calendar (if original and new calendar both represent the real world).  I think this should be a step towards solving #185, and also may be useful for UM users if https://github.com/SciTools/iris/issues/3561 is implemented.

@larsbarring I'd appreciate any feedback you may have on this.