### PR TITLE
black py310 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ local_scheme = "dirty-tag"
 
 [tool.black]
 line-length = 79
-# TBD: add "py310" when supported on pre-commit.ci
-target-version = ["py38", "py39"]
+target-version = ["py38", "py39", "py310"]
 include = '\.pyi?$'
 exclude = '''
 (


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR extends the `black` coverage to `python` 3.10, now that it is available from the `pre-commit.ci` service.

Confusingly, previously `pre-commit.ci` was behind `black` in offering the ability to perform `black` CI `pre-commit` checks on a pull-request for `python` 3.10. Now it appears that both are in alignment, so we can enable this as part of our CI coverage.
