### PR TITLE
use github app for lock pr token

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -109,11 +109,19 @@ jobs:
         name: lock-artifacts
         path: ${{ github.workspace }}/requirements/locks
 
+    - name: "Generate token"
+      uses: tibdex/github-app-token@v1
+      id: generate-token
+      with:
+        app_id: ${{ secrets.AUTH_APP_ID }}
+        private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
     - name: "Push pull-request"
       id: cpr
       # v3.12.1 (release date 31 Jan 2022)
       uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27
       with:
+        token: ${{ steps.generate-token.outputs.token }}
         add-paths: ${{ github.workspace }}/requirements/locks/*.txt
         commit-message: "updated conda lock files"
         branch: conda-lock-auto-update
@@ -121,8 +129,6 @@ jobs:
         title: "[cf-units.ci] conda lock auto-update"
         body: |
           Conda lock files auto-updated to latest resolved environment for `cf-units` dependencies.
-          
-          ### If the full suite of PR checks have not run, please close and re-open this pull request to trigger them.
         labels: |
           New: Pull Request
           Bot


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR enables the automatic triggering of CI on `ci-locks` GHA workflow generated PR to update the `conda-lock` files.

The same SciTools GitHub App using in `iris` has also been installed for this repository.

Reference https://github.com/SciTools/iris/pull/4817
