### PR TITLE
update ci-wheels gha for tags release

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -13,6 +13,8 @@ on:
   pull_request:
 
   push:
+    tags:
+      - "v*"
     branches-ignore:
       - "conda-lock-auto-update"
       - "pre-commit-ci-update-config"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR updates the `ci-wheels` GHA workflow to trigger on a release tag.
