### PR TITLE
add ci concurrency group

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: "3 0 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-locks:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,6 +14,9 @@ on:
       - "pre-commit-ci-update-config"
       - "dependabot/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-tests:

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -20,6 +20,9 @@ on:
       - "pre-commit-ci-update-config"
       - "dependabot/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_bdist:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR adds a GHA `concurrency` group to the workflows in order to enable efficient cancellation of jobs
