### PR TITLE
fix rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,10 @@ build:
   os: ubuntu-20.04
   tools:
     python: mambaforge-4.10
+  jobs:
+    post_checkout:
+      - git fetch --unshallow
+      - git fetch --all
 
 conda:
   environment: requirements/cf-units.yml


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR reboots the building of documentation on `readthedocs`.

It also requires the following [user-defined environment variables](https://docs.readthedocs.io/en/stable/environment-variables.html#user-defined-environment-variables) to be configured on the `cf-units` RTD account:
- `UDUNITS2_INCDIR`
- `UDUNITS2_LIBDIR`
- `UNUNITS2_XML_PATH`

These environment variables are required as RTD performs a `pip install` and as a result attempts to build the binary wheel from the sdist of the code.

See the successfully [rendered documentation](https://bjlittle-cf-units.readthedocs.io/en/latest/) associated with this PR on my private clone of the `cf-units` RTD.