### PR TITLE
update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 [![Documentation Status](https://readthedocs.org/projects/cf-units/badge/?version=latest)](https://cf-units.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://codecov.io/gh/SciTools/cf-units/branch/main/graph/badge.svg?token=6LlYlyTUZG)](https://codecov.io/gh/SciTools/cf-units)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/SciTools/cf-units/main.svg)](https://results.pre-commit.ci/latest/github/SciTools/cf-units/main)
-,
+\
 [![conda-forge downloads](https://img.shields.io/conda/vn/conda-forge/cf-units?color=orange&label=conda-forge&logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/cf-units)
 [![PyPI](https://img.shields.io/pypi/v/cf-units?color=orange&label=pypi&logo=python&logoColor=white)](https://pypi.org/project/cf-units/)
 [![Latest version](https://img.shields.io/github/tag/SciTools/cf-units)](https://github.com/SciTools/cf-units/releases)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3723086.svg)](https://doi.org/10.5281/zenodo.3723086)
-,
+\
 [![Black](https://img.shields.io/badge/code%20style-black-000000)](https://github.com/psf/black)
 [![Flake8](https://img.shields.io/badge/lint-flake8-lightgrey)](https://github.com/PyCQA/flake8)
 [![isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-,
+\
 [![Licence](https://img.shields.io/github/license/SciTools/cf-units)](COPYING)
 [![Contributors](https://img.shields.io/github/contributors/SciTools/cf-units)](https://github.com/SciTools/cf-units/graphs/contributors)
 [![Commits since last release](https://img.shields.io/github/commits-since/SciTools/cf-units/latest.svg)](https://github.com/SciTools/cf-units/commits/main)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,81 @@
-# [cf-units](https://cf-units.readthedocs.io/en/latest/)
+<h1 align='center'>
+    cf-units
+</h1>
 
-#### Units of measure as defined by the Climate and Forecast (CF) metadata conventions.
+<h4 align='center'>
+    Units of measure as defined by the Climate and Forecast (CF) Metadata Conventions
+</h4>
 
-[comment]: # (https://shields.io/ is a good source of these)
-[![Build Status](https://api.cirrus-ci.com/github/SciTools/cf-units.svg)](https://cirrus-ci.com/github/SciTools/cf-units)
-[![Coverage Status](https://codecov.io/gh/SciTools/cf-units/branch/main/graph/badge.svg?token=6LlYlyTUZG)](https://codecov.io/gh/SciTools/cf-units)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/SciTools/cf-units/main.svg)](https://results.pre-commit.ci/latest/github/SciTools/cf-units/main)
-,
-[![conda-forge downloads](https://img.shields.io/conda/vn/conda-forge/cf-units?color=orange&label=conda-forge&logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/cf-units)
-[![PyPI](https://img.shields.io/pypi/v/cf-units?color=orange&label=pypi&logo=python&logoColor=white)](https://pypi.org/project/cf-units/)
-[![Latest version](https://img.shields.io/github/tag/SciTools/cf-units)](https://github.com/SciTools/cf-units/releases)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3723086.svg)](https://doi.org/10.5281/zenodo.3723086)
-,
-[![Black](https://img.shields.io/badge/code%20style-black-000000)](https://github.com/psf/black)
-[![Flake8](https://img.shields.io/badge/lint-flake8-lightgrey)](https://github.com/PyCQA/flake8)
-[![isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-,
-[![Licence](https://img.shields.io/github/license/SciTools/cf-units)](COPYING)
-[![Contributors](https://img.shields.io/github/contributors/SciTools/cf-units)](https://github.com/SciTools/cf-units/graphs/contributors)
-[![Commits since last release](https://img.shields.io/github/commits-since/SciTools/cf-units/latest.svg)](https://github.com/SciTools/cf-units/commits/main)
+<p align='center'>
+<a href='https://github.com/SciTools/cf-units/actions/workflows/ci-tests.yml'>
+    <img src='https://github.com/SciTools/cf-units/actions/workflows/ci-tests.yml/badge.svg?branch=main'
+         alt='ci-tests'>
+</a>
+<a href='https://github.com/SciTools/cf-units/actions/workflows/ci-wheels.yml'>
+   <img src='https://github.com/SciTools/cf-units/actions/workflows/ci-wheels.yml/badge.svg?branch=main'
+        alt='ci-wheels'>
+</a>
+<a href='https://github.com/SciTools/cf-units/actions/workflows/ci-locks.yml'>
+   <img src='https://github.com/SciTools/cf-units/actions/workflows/ci-locks.yml/badge.svg?branch=main'
+        alt='ci-locks>
+</a>
+<a href='https://cf-units.readthedocs.io/en/latest/?badge=latest'>
+    <img src='https://readthedocs.org/projects/cf-units/badge/?version=latest'
+         alt='Documentation Status' />
+</a>
+<a href='https://results.pre-commit.ci/latest/github/SciTools/cf-units/main'>
+   <img src='https://results.pre-commit.ci/badge/github/SciTools/cf-units/main.svg'
+        alt='pre-commit.ci'>
+</a>
+<a href='https://codecov.io/gh/SciTools/cf-units'>
+   <img src='https://codecov.io/gh/SciTools/cf-units/branch/main/graph/badge.svg?token=6LlYlyTUZG'
+        alt='codecov'>
+</a>
+</p>
+
+<p align='center'>
+<a href='https://anaconda.org/conda-forge/cf-units'>
+   <img src='https://img.shields.io/conda/vn/conda-forge/cf-units?color=orange&label=conda-forge&logo=conda-forge&logoColor=white'
+        alt='conda-forge'>
+</a>
+<a href='https://pypi.org/project/cf-units/'>
+   <img src='https://img.shields.io/pypi/v/cf-units?color=orange&label=pypi&logo=python&logoColor=white'
+        alt='pypi'>
+</a>
+<a href='https://github.com/SciTools/cf-units/releases'>
+   <img src='https://img.shields.io/github/tag/SciTools/cf-units'
+        alt='tags'>
+</a>
+<a href='https://github.com/SciTools/cf-units/commits/main'>
+   <img src='https://img.shields.io/github/commits-since/SciTools/cf-units/latest.svg'
+        alt='commits'>
+</a>
+<a href='https://github.com/SciTools/cf-units/graphs/contributors'>
+   <img src='https://img.shields.io/github/contributors/SciTools/cf-units'
+        alt='contributors'>
+</a>
+</p>
+
+<p align='center'>
+<a href='https://doi.org/10.5281/zenodo.3723086'>
+   <img src='https://zenodo.org/badge/DOI/10.5281/zenodo.3723086.svg'
+        alt='doi'>
+</a>
+<img src='https://img.shields.io/github/license/SciTools/cf-units'
+     alt='licence'>
+<a href='https://github.com/psf/black'>
+   <img src='https://img.shields.io/badge/code%20style-black-000000'
+        alt='black'>
+</a>
+<a href='https://github.com/PyCQA/flake8'>
+    <img src='https://img.shields.io/badge/lint-flake8-lightgrey'
+         alt='flake8'>
+</a>
+<a href='https://pycqa.github.io/isort/'>
+   <img src='https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336'
+        alt='isort'>
+</a>
+</p>
 
 # Table of contents
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [cf-units](https://cf-units.readthedocs.io/en/latest/)
 
-#### Units of measure as defined by the Climate and Forecast (CF) metadata conventions.
+#### Units of measure as defined by the Climate and Forecast (CF) Metadata Conventions.
 
 [comment]: # (https://shields.io/ is a good source of these)
 [![ci-tests](https://github.com/SciTools/cf-units/actions/workflows/ci-tests.yml/badge.svg?branch=main)](https://github.com/SciTools/cf-units/actions/workflows/ci-tests.yml)
@@ -22,7 +22,6 @@
 [![Licence](https://img.shields.io/github/license/SciTools/cf-units)](COPYING)
 [![Contributors](https://img.shields.io/github/contributors/SciTools/cf-units)](https://github.com/SciTools/cf-units/graphs/contributors)
 [![Commits since last release](https://img.shields.io/github/commits-since/SciTools/cf-units/latest.svg)](https://github.com/SciTools/cf-units/commits/main)
-
 
 # Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,81 +1,28 @@
-<h1 align='center'>
-    cf-units
-</h1>
+# [cf-units](https://cf-units.readthedocs.io/en/latest/)
 
-<h4 align='center'>
-    Units of measure as defined by the Climate and Forecast (CF) Metadata Conventions
-</h4>
+#### Units of measure as defined by the Climate and Forecast (CF) metadata conventions.
 
-<p align='center'>
-<a href='https://github.com/SciTools/cf-units/actions/workflows/ci-tests.yml'>
-    <img src='https://github.com/SciTools/cf-units/actions/workflows/ci-tests.yml/badge.svg?branch=main'
-         alt='ci-tests'>
-</a>
-<a href='https://github.com/SciTools/cf-units/actions/workflows/ci-wheels.yml'>
-   <img src='https://github.com/SciTools/cf-units/actions/workflows/ci-wheels.yml/badge.svg?branch=main'
-        alt='ci-wheels'>
-</a>
-<a href='https://github.com/SciTools/cf-units/actions/workflows/ci-locks.yml'>
-   <img src='https://github.com/SciTools/cf-units/actions/workflows/ci-locks.yml/badge.svg?branch=main'
-        alt='ci-locks>
-</a>
-<a href='https://cf-units.readthedocs.io/en/latest/?badge=latest'>
-    <img src='https://readthedocs.org/projects/cf-units/badge/?version=latest'
-         alt='Documentation Status' />
-</a>
-<a href='https://results.pre-commit.ci/latest/github/SciTools/cf-units/main'>
-   <img src='https://results.pre-commit.ci/badge/github/SciTools/cf-units/main.svg'
-        alt='pre-commit.ci'>
-</a>
-<a href='https://codecov.io/gh/SciTools/cf-units'>
-   <img src='https://codecov.io/gh/SciTools/cf-units/branch/main/graph/badge.svg?token=6LlYlyTUZG'
-        alt='codecov'>
-</a>
-</p>
+[comment]: # (https://shields.io/ is a good source of these)
+[![ci-tests](https://github.com/SciTools/cf-units/actions/workflows/ci-tests.yml/badge.svg?branch=main)](https://github.com/SciTools/cf-units/actions/workflows/ci-tests.yml)
+[![ci-wheels](https://github.com/SciTools/cf-units/actions/workflows/ci-wheels.yml/badge.svg?branch=main)](https://github.com/SciTools/cf-units/actions/workflows/ci-wheels.yml)
+[![ci-locks](https://github.com/SciTools/cf-units/actions/workflows/ci-locks.yml/badge.svg?branch=main)](https://github.com/SciTools/cf-units/actions/workflows/ci-locks.yml)
+[![Documentation Status](https://readthedocs.org/projects/cf-units/badge/?version=latest)](https://cf-units.readthedocs.io/en/latest/?badge=latest)
+[![Coverage Status](https://codecov.io/gh/SciTools/cf-units/branch/main/graph/badge.svg?token=6LlYlyTUZG)](https://codecov.io/gh/SciTools/cf-units)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/SciTools/cf-units/main.svg)](https://results.pre-commit.ci/latest/github/SciTools/cf-units/main)
+,
+[![conda-forge downloads](https://img.shields.io/conda/vn/conda-forge/cf-units?color=orange&label=conda-forge&logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/cf-units)
+[![PyPI](https://img.shields.io/pypi/v/cf-units?color=orange&label=pypi&logo=python&logoColor=white)](https://pypi.org/project/cf-units/)
+[![Latest version](https://img.shields.io/github/tag/SciTools/cf-units)](https://github.com/SciTools/cf-units/releases)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3723086.svg)](https://doi.org/10.5281/zenodo.3723086)
+,
+[![Black](https://img.shields.io/badge/code%20style-black-000000)](https://github.com/psf/black)
+[![Flake8](https://img.shields.io/badge/lint-flake8-lightgrey)](https://github.com/PyCQA/flake8)
+[![isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
+,
+[![Licence](https://img.shields.io/github/license/SciTools/cf-units)](COPYING)
+[![Contributors](https://img.shields.io/github/contributors/SciTools/cf-units)](https://github.com/SciTools/cf-units/graphs/contributors)
+[![Commits since last release](https://img.shields.io/github/commits-since/SciTools/cf-units/latest.svg)](https://github.com/SciTools/cf-units/commits/main)
 
-<p align='center'>
-<a href='https://anaconda.org/conda-forge/cf-units'>
-   <img src='https://img.shields.io/conda/vn/conda-forge/cf-units?color=orange&label=conda-forge&logo=conda-forge&logoColor=white'
-        alt='conda-forge'>
-</a>
-<a href='https://pypi.org/project/cf-units/'>
-   <img src='https://img.shields.io/pypi/v/cf-units?color=orange&label=pypi&logo=python&logoColor=white'
-        alt='pypi'>
-</a>
-<a href='https://github.com/SciTools/cf-units/releases'>
-   <img src='https://img.shields.io/github/tag/SciTools/cf-units'
-        alt='tags'>
-</a>
-<a href='https://github.com/SciTools/cf-units/commits/main'>
-   <img src='https://img.shields.io/github/commits-since/SciTools/cf-units/latest.svg'
-        alt='commits'>
-</a>
-<a href='https://github.com/SciTools/cf-units/graphs/contributors'>
-   <img src='https://img.shields.io/github/contributors/SciTools/cf-units'
-        alt='contributors'>
-</a>
-</p>
-
-<p align='center'>
-<a href='https://doi.org/10.5281/zenodo.3723086'>
-   <img src='https://zenodo.org/badge/DOI/10.5281/zenodo.3723086.svg'
-        alt='doi'>
-</a>
-<img src='https://img.shields.io/github/license/SciTools/cf-units'
-     alt='licence'>
-<a href='https://github.com/psf/black'>
-   <img src='https://img.shields.io/badge/code%20style-black-000000'
-        alt='black'>
-</a>
-<a href='https://github.com/PyCQA/flake8'>
-    <img src='https://img.shields.io/badge/lint-flake8-lightgrey'
-         alt='flake8'>
-</a>
-<a href='https://pycqa.github.io/isort/'>
-   <img src='https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336'
-        alt='isort'>
-</a>
-</p>
 
 # Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
 </a>
 </p>
 
-# Table of contents
+# Table of Contents
 
 [comment]: # (NOTE: toc auto-generated with
   https://github.com/jonschlinkert/markdown-toc
@@ -110,7 +110,7 @@ Documentation can be found at <https://cf-units.readthedocs.io/en/latest/>.
     >>> m.convert(1500, km)
     1.5
 
-## Get in touch
+## Get in Touch
 
 - Questions, ideas, general discussion or announcements
   of related projects: use the
@@ -119,7 +119,7 @@ Documentation can be found at <https://cf-units.readthedocs.io/en/latest/>.
   [submit a GitHub issue](https://github.com/SciTools/cf-units/issues).
 - Suggest features: see our [contributing guide](.github/CONTRIBUTING.md).
 
-## Credits, copyright and license
+## Credits, Copyright and License
 
 cf-units is developed collaboratively under the SciTools umbrella.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [![Contributors](https://img.shields.io/github/contributors/SciTools/cf-units)](https://github.com/SciTools/cf-units/graphs/contributors)
 [![Commits since last release](https://img.shields.io/github/commits-since/SciTools/cf-units/latest.svg)](https://github.com/SciTools/cf-units/commits/main)
 
-# Table of Contents
+## Table of Contents
 
 [comment]: # (NOTE: toc auto-generated with
   https://github.com/jonschlinkert/markdown-toc


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR updates and refreshes the `README.md` badges.

Notably, badges to the GHA CI and RTD have been added, and the badge to the now defunct `cirris-ci` has been removed.

The changes render as follows:

![image](https://user-images.githubusercontent.com/2051656/178484881-0a2bc5d0-d193-4e43-8420-321b5dad5602.png)

See [here](https://github.com/bjlittle/cf-units/tree/add-badges#----cf-units).
