### PR TITLE
add readthedocs common conda environment link

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,10 @@ build:
       # perform a "git fetch --unshallow" when the cf-units repo
       # becomes incomplete i.e., there is a .git/shallow.
       - git fetch --all
+    pre_install:
+      # create a "common" link to the underlying rtd conda environment,
+      # which maybe named "latest", "stable" or the cf-units version
+      - ln -s ${CONDA_ENVS_PATH}/${CONDA_DEFAULT_ENV} ${CONDA_ENVS_PATH}/common
 
 conda:
   environment: requirements/cf-units.yml

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 
 - [Overview](#overview)
   - [Example](#example)
-- [Get in touch](#get-in-touch)
-- [Credits, copyright and license](#credits-copyright-and-license)
+- [Get in Touch](#get-in-touch)
+- [Credits, Copyright and License](#credits-copyright-and-license)
 
 ## Overview
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR creates a common symbolic link on RTD to access the underlying RTD `conda` environment.

This is to allow one means for the `cf-units` user-defined environment variables to access the various `conda` environments which maybe named as `latest`, `stable` or by the `cf-units` version e.g., `3.1.1`.
