### PR TITLE
Deprecate `cf_units.util.approx_equal`

### DIFF
--- a/cf_units/__init__.py
+++ b/cf_units/__init__.py
@@ -15,6 +15,7 @@ See also: `UDUNITS-2
 """
 
 import copy
+import math
 from contextlib import contextmanager
 
 import cftime
@@ -32,7 +33,7 @@ from cf_units._udunits2 import (
 
 from . import config
 from ._version import version as __version__  # noqa: F401
-from .util import _OrderedHashable, approx_equal
+from .util import _OrderedHashable
 
 __all__ = [
     "CALENDARS",
@@ -1663,15 +1664,15 @@ class Unit(_OrderedHashable):
             # But if the power is of the form 1/N, where N is an integer
             # (within a certain acceptable accuracy) then we can find the Nth
             # root.
-            if not approx_equal(power, 0.0) and abs(power) < 1:
-                if not approx_equal(1 / power, round(1 / power)):
+            if not math.isclose(power, 0.0) and abs(power) < 1:
+                if not math.isclose(1 / power, round(1 / power)):
                     raise ValueError("Cannot raise a unit by a decimal.")
                 root = int(round(1 / power))
                 result = self.root(root)
             else:
                 # Failing that, check for powers which are (very nearly) simple
                 # integer values.
-                if not approx_equal(power, round(power)):
+                if not math.isclose(power, round(power)):
                     msg = "Cannot raise a unit by a decimal (got %s)." % power
                     raise ValueError(msg)
                 power = int(round(power))

--- a/cf_units/util.py
+++ b/cf_units/util.py
@@ -18,6 +18,9 @@ def approx_equal(a, b, max_absolute_error=1e-10, max_relative_error=1e-10):
     Returns whether two numbers are almost equal, allowing for the
     finite precision of floating point numbers.
 
+    .. deprecated:: 3.2.0
+       Instead please use :func:`math.isclose`.
+
     """
     msg = (
         "cf_units.util.approx_equal has been deprecated and will be removed.  "

--- a/cf_units/util.py
+++ b/cf_units/util.py
@@ -9,6 +9,7 @@ Miscellaneous utility functions.
 """
 
 import abc
+import warnings
 from collections.abc import Hashable
 
 
@@ -18,6 +19,12 @@ def approx_equal(a, b, max_absolute_error=1e-10, max_relative_error=1e-10):
     finite precision of floating point numbers.
 
     """
+    msg = (
+        "cf_units.util.approx_equal has been deprecated and will be removed.  "
+        "Please use math.isclose instead."
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
     # Deal with numbers close to zero
     if abs(a - b) < max_absolute_error:
         return True


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
As for https://github.com/SciTools/iris/pull/4514, I don't think we need to be maintaining this function.  Unlike the Iris version, I didn't bother updating the docstring, because this function isn't included in the cf-units docs!