### PR TITLE
setup method is not a test

### DIFF
--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -79,7 +79,7 @@ class Test_convert__calendar:
     class MyStr(str):
         pass
 
-    def test_gregorian_calendar_conversion_setup(self):
+    def gregorian_calendar_conversion_setup(self):
         # Reproduces a situation where a unit's gregorian calendar would not
         # match (using the `is` operator) to the literal string 'gregorian',
         # causing an `is not` test to return a false negative.
@@ -94,15 +94,15 @@ class Test_convert__calendar:
         return expected, result
 
     def test_gregorian_calendar_conversion_array(self):
-        expected, result = self.test_gregorian_calendar_conversion_setup()
+        expected, result = self.gregorian_calendar_conversion_setup()
         np.testing.assert_array_equal(expected, result)
 
     def test_gregorian_calendar_conversion_dtype(self):
-        expected, result = self.test_gregorian_calendar_conversion_setup()
+        expected, result = self.gregorian_calendar_conversion_setup()
         assert expected.dtype == result.dtype
 
     def test_gregorian_calendar_conversion_shape(self):
-        expected, result = self.test_gregorian_calendar_conversion_setup()
+        expected, result = self.gregorian_calendar_conversion_setup()
         assert expected.shape == result.shape
 
     def test_non_gregorian_calendar_conversion_dtype(self):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Pytest was throwing a warning because it ran this method as a test, and tests shouldn't return anything.  Changing the name ensures pytest doesn't think it's a test.