### PR TITLE
support py311 locks

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -27,7 +27,7 @@ jobs:
       ENV_NAME: "ci-locks"
     strategy:
       matrix:
-        lock: [py38-lock, py39-lock, py310-lock]
+        lock: [py38-lock, py39-lock, py310-lock, py311-lock]
     steps:
     - name: "Checkout"
       uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
 description = Units of measure as required by the Climate and Forecast (CF) metadata conventions
 download_url = https://github.com/SciTools/cf-units

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
     tox-run-command
  
  
-[testenv:py{38,39,310}-lock]
+[testenv:py{38,39,310,311}-lock]
 allowlist_externals =
     cp
 changedir =


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR extends the conda lock file generation to support `py311`.

After this lands, I'll extend the `tox` testing to cover `py311` too, but in a separate PR, as the lock files require to be available before we turn on testing.

We can manually run the `ci-locks` to auto generated the PR containing `py311` dependencies.