### PR TITLE
update deps min pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 # Defined by PEP 518
 requires = [
-  "setuptools>=45",
-  "setuptools_scm[toml]>=7.0",
+  "setuptools>=61",
+  "setuptools_scm[toml]>=7",
   "wheel",
   "oldest-supported-numpy",
   "Cython"

--- a/requirements/cf-units.yml
+++ b/requirements/cf-units.yml
@@ -5,14 +5,14 @@ channels:
 
 dependencies:
 # setup dependencies
-  - setuptools >=45
-  - setuptools_scm >=7.0
+  - setuptools >=61
+  - setuptools_scm >=7
   - cython
   - numpy
 
 # core dependencies
   - antlr-python-runtime 4.7.2.*
-  - cftime>=1.2
+  - cftime>=1.5.2
   - numpy
   - udunits2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ version = attr: cf_units.__version__
 include_package_data = True
 install_requires =
     antlr4-python3-runtime ==4.7.2
-    cftime >=1.2
+    cftime >=1.5.2
     jinja2
     numpy
     # udunits2 cannot be installed with pip, and it is expected to be


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR bumps some minimum dependency pins for `cftime`, `setuptools` and `setuptools-scm`.

Note that, the `cftime` minimum pin here aligns with the minimum pin within the `cf_units-feedstock` recipe, see [here](https://github.com/conda-forge/cf_units-feedstock/blob/main/recipe/meta.yaml#L34).