### PR TITLE
adopt ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,22 +25,15 @@ repos:
         types: [file, python]
         args: [--config=./pyproject.toml]
 
--   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-    -   id: flake8
-        types: [file, python]
-        args: [--config=./setup.cfg]
-
--   repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-    -   id: isort
-        types: [file, python]
-        args: [--filter-files]
-
 -   repo: https://github.com/aio-libs/sort-all
     rev: v1.2.0
     hooks:
     -   id: sort-all
         types: [file, python]
+
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.260"
+    hooks:
+    -   id: ruff
+        types: [file, python]
+        args: [--fix]

--- a/cf_units/_udunits2_parser/__init__.py
+++ b/cf_units/_udunits2_parser/__init__.py
@@ -15,8 +15,7 @@ from .parser.udunits2ParserVisitor import udunits2ParserVisitor
 
 # Dictionary mapping token rule id to token name.
 TOKEN_ID_NAMES = {
-    getattr(udunits2Lexer, rule, None): rule
-    for rule in udunits2Lexer.ruleNames
+    getattr(udunits2Lexer, rule, None): rule for rule in udunits2Lexer.ruleNames
 }
 
 
@@ -169,7 +168,7 @@ class SyntaxErrorRaiser(ErrorListener):
 
     def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
         # https://stackoverflow.com/a/36367357/741316
-        context = ("inline", line, column + 2, "'{}'".format(self.unit_string))
+        context = ("inline", line, column + 2, f"'{self.unit_string}'")
         syntax_error = SyntaxError(msg, context)
         raise syntax_error from None
 
@@ -192,7 +191,7 @@ def _debug_tokens(unit_string):
             continue
         token_type_idx = token.type
         rule = TOKEN_ID_NAMES[token_type_idx]
-        print("%s: %s" % (token.text, rule))
+        print(f"{token.text}: {rule}")
 
 
 def normalize(unit_string):

--- a/cf_units/_udunits2_parser/compile.py
+++ b/cf_units/_udunits2_parser/compile.py
@@ -16,10 +16,10 @@ You're welcome ;).
 """
 
 import collections
+from pathlib import Path
 import re
 import subprocess
 import urllib.request
-from pathlib import Path
 
 try:
     import jinja2
@@ -41,12 +41,10 @@ def expand_lexer(source, target):
     MODE_P = re.compile(r"mode ([A-Z_]+)\;")
     TOKEN_P = re.compile(r"([A-Z_]+) ?\:.*")
 
-    with open(source, "r") as fh:
+    with open(source) as fh:
         content = fh.read()
 
-    template = jinja2.Environment(loader=jinja2.BaseLoader).from_string(
-        content
-    )
+    template = jinja2.Environment(loader=jinja2.BaseLoader).from_string(content)
 
     current_mode = "DEFAULT_MODE"
 

--- a/cf_units/_udunits2_parser/graph.py
+++ b/cf_units/_udunits2_parser/graph.py
@@ -27,10 +27,8 @@ class Node:
 
     def _repr_ctx(self):
         # Return a dictionary that is useful for passing to string.format.
-        kwargs = ", ".join(
-            "{}={!r}".format(key, value) for key, value in self._attrs.items()
-        )
-        return dict(cls_name=self.__class__.__name__, kwargs=kwargs)
+        kwargs = ", ".join(f"{key}={value!r}" for key, value in self._attrs.items())
+        return {"cls_name": self.__class__.__name__, "kwargs": kwargs}
 
     def __repr__(self):
         return "{cls_name}({kwargs})".format(**self._repr_ctx())
@@ -49,7 +47,7 @@ class Terminal(Node):
         return []
 
     def __str__(self):
-        return "{}".format(self.content)
+        return f"{self.content}"
 
 
 class Operand(Terminal):

--- a/cf_units/_udunits2_parser/parser/udunits2Lexer.py
+++ b/cf_units/_udunits2_parser/parser/udunits2Lexer.py
@@ -1,7 +1,8 @@
-# Generated from /Users/pelson/dev/scitools/cf-units/cf_units/_udunits2_parser/parser/udunits2Lexer.g4 by ANTLR 4.7.2
-import sys
+# Generated from
+# /Users/pelson/dev/scitools/cf-units/cf_units/_udunits2_parser/parser/udunits2Lexer.g4 by ANTLR 4.7.2  # noqa: E501
 from io import StringIO
-from typing.io import TextIO
+import sys
+from typing import TextIO
 
 from antlr4 import *
 

--- a/cf_units/_udunits2_parser/parser/udunits2Parser.py
+++ b/cf_units/_udunits2_parser/parser/udunits2Parser.py
@@ -1,8 +1,8 @@
-# Generated from /Users/pelson/dev/scitools/cf-units/cf_units/_udunits2_parser/udunits2Parser.g4 by ANTLR 4.7.2
-# encoding: utf-8
-import sys
+# Generated
+# from /Users/pelson/dev/scitools/cf-units/cf_units/_udunits2_parser/udunits2Parser.g4 by ANTLR 4.7.2  # noqa: E501
 from io import StringIO
-from typing.io import TextIO
+import sys
+from typing import TextIO
 
 from antlr4 import *
 
@@ -200,9 +200,7 @@ class udunits2Parser(Parser):
             return self.getToken(udunits2Parser.EOF, 0)
 
         def shift_spec(self):
-            return self.getTypedRuleContext(
-                udunits2Parser.Shift_specContext, 0
-            )
+            return self.getTypedRuleContext(udunits2Parser.Shift_specContext, 0)
 
         def getRuleIndex(self):
             return udunits2Parser.RULE_unit_spec
@@ -283,9 +281,7 @@ class udunits2Parser(Parser):
                 return visitor.visitChildren(self)
 
     def shift_spec(self):
-        localctx = udunits2Parser.Shift_specContext(
-            self, self._ctx, self.state
-        )
+        localctx = udunits2Parser.Shift_specContext(self, self._ctx, self.state)
         self.enterRule(localctx, 2, self.RULE_shift_spec)
         self._la = 0  # Token type
         try:
@@ -414,9 +410,7 @@ class udunits2Parser(Parser):
                     _prevctx = localctx
                     self.state = 66
                     self._errHandler.sync(self)
-                    la_ = self._interp.adaptivePredict(
-                        self._input, 7, self._ctx
-                    )
+                    la_ = self._interp.adaptivePredict(self._input, 7, self._ctx)
                     if la_ == 1:
                         localctx = udunits2Parser.ProductContext(
                             self, _parentctx, _parentState
@@ -536,9 +530,7 @@ class udunits2Parser(Parser):
             self.parser = parser
 
         def basic_spec(self):
-            return self.getTypedRuleContext(
-                udunits2Parser.Basic_specContext, 0
-            )
+            return self.getTypedRuleContext(udunits2Parser.Basic_specContext, 0)
 
         def integer(self):
             return self.getTypedRuleContext(udunits2Parser.IntegerContext, 0)
@@ -622,9 +614,7 @@ class udunits2Parser(Parser):
             return self.getToken(udunits2Parser.OPEN_PAREN, 0)
 
         def shift_spec(self):
-            return self.getTypedRuleContext(
-                udunits2Parser.Shift_specContext, 0
-            )
+            return self.getTypedRuleContext(udunits2Parser.Shift_specContext, 0)
 
         def CLOSE_PAREN(self):
             return self.getToken(udunits2Parser.CLOSE_PAREN, 0)
@@ -642,9 +632,7 @@ class udunits2Parser(Parser):
                 return visitor.visitChildren(self)
 
     def basic_spec(self):
-        localctx = udunits2Parser.Basic_specContext(
-            self, self._ctx, self.state
-        )
+        localctx = udunits2Parser.Basic_specContext(self, self._ctx, self.state)
         self.enterRule(localctx, 8, self.RULE_basic_spec)
         try:
             self.state = 90
@@ -717,9 +705,7 @@ class udunits2Parser(Parser):
             self.enterOuterAlt(localctx, 1)
             self.state = 92
             _la = self._input.LA(1)
-            if not (
-                _la == udunits2Parser.SIGNED_INT or _la == udunits2Parser.INT
-            ):
+            if not (_la == udunits2Parser.SIGNED_INT or _la == udunits2Parser.INT):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
@@ -802,9 +788,7 @@ class udunits2Parser(Parser):
             return self.getToken(udunits2Parser.INT, 0)
 
         def signed_clock(self):
-            return self.getTypedRuleContext(
-                udunits2Parser.Signed_clockContext, 0
-            )
+            return self.getTypedRuleContext(udunits2Parser.Signed_clockContext, 0)
 
         def WS(self, i: int = None):
             if i is None:
@@ -813,9 +797,7 @@ class udunits2Parser(Parser):
                 return self.getToken(udunits2Parser.WS, i)
 
         def timezone_offset(self):
-            return self.getTypedRuleContext(
-                udunits2Parser.Timezone_offsetContext, 0
-            )
+            return self.getTypedRuleContext(udunits2Parser.Timezone_offsetContext, 0)
 
         def DT_T_CLOCK(self):
             return self.getToken(udunits2Parser.DT_T_CLOCK, 0)
@@ -844,9 +826,7 @@ class udunits2Parser(Parser):
                 self.enterOuterAlt(localctx, 1)
                 self.state = 98
                 _la = self._input.LA(1)
-                if not (
-                    _la == udunits2Parser.INT or _la == udunits2Parser.DATE
-                ):
+                if not (_la == udunits2Parser.INT or _la == udunits2Parser.DATE):
                     self._errHandler.recoverInline(self)
                 else:
                     self._errHandler.reportMatch(self)
@@ -857,9 +837,7 @@ class udunits2Parser(Parser):
                 self.enterOuterAlt(localctx, 2)
                 self.state = 99
                 _la = self._input.LA(1)
-                if not (
-                    _la == udunits2Parser.INT or _la == udunits2Parser.DATE
-                ):
+                if not (_la == udunits2Parser.INT or _la == udunits2Parser.DATE):
                     self._errHandler.recoverInline(self)
                 else:
                     self._errHandler.reportMatch(self)
@@ -967,9 +945,7 @@ class udunits2Parser(Parser):
                 return visitor.visitChildren(self)
 
     def signed_clock(self):
-        localctx = udunits2Parser.Signed_clockContext(
-            self, self._ctx, self.state
-        )
+        localctx = udunits2Parser.Signed_clockContext(self, self._ctx, self.state)
         self.enterRule(localctx, 16, self.RULE_signed_clock)
         try:
             self.state = 123
@@ -1027,9 +1003,7 @@ class udunits2Parser(Parser):
                 return visitor.visitChildren(self)
 
     def timezone_offset(self):
-        localctx = udunits2Parser.Timezone_offsetContext(
-            self, self._ctx, self.state
-        )
+        localctx = udunits2Parser.Timezone_offsetContext(self, self._ctx, self.state)
         self.enterRule(localctx, 18, self.RULE_timezone_offset)
         try:
             self.state = 127
@@ -1057,8 +1031,8 @@ class udunits2Parser(Parser):
         return localctx
 
     def sempred(self, localctx: RuleContext, ruleIndex: int, predIndex: int):
-        if self._predicates == None:
-            self._predicates = dict()
+        if self._predicates is None:
+            self._predicates = {}
         self._predicates[2] = self.product_sempred
         pred = self._predicates.get(ruleIndex, None)
         if pred is None:

--- a/cf_units/_udunits2_parser/parser/udunits2ParserVisitor.py
+++ b/cf_units/_udunits2_parser/parser/udunits2ParserVisitor.py
@@ -1,4 +1,5 @@
-# Generated from /Users/pelson/dev/scitools/cf-units/cf_units/_udunits2_parser/udunits2Parser.g4 by ANTLR 4.7.2
+# Generated from
+# /Users/pelson/dev/scitools/cf-units/cf_units/_udunits2_parser/udunits2Parser.g4 by ANTLR 4.7.2  # noqa: E501
 from antlr4 import *
 
 if __name__ is not None and "." in __name__:
@@ -6,7 +7,8 @@ if __name__ is not None and "." in __name__:
 else:
     from udunits2Parser import udunits2Parser
 
-# This class defines a complete generic visitor for a parse tree produced by udunits2Parser.
+# This class defines a complete generic visitor for a parse tree
+# produced by udunits2Parser.
 
 
 class udunits2ParserVisitor(ParseTreeVisitor):

--- a/cf_units/config.py
+++ b/cf_units/config.py
@@ -5,8 +5,8 @@
 
 
 import configparser
-import sys
 from pathlib import Path
+import sys
 from tempfile import NamedTemporaryFile
 
 

--- a/cf_units/tests/integration/parse/test_graph.py
+++ b/cf_units/tests/integration/parse/test_graph.py
@@ -3,8 +3,8 @@
 # This file is part of cf-units and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
 
-import cf_units._udunits2_parser.graph as g
 from cf_units._udunits2_parser import parse
+import cf_units._udunits2_parser.graph as g
 
 
 def test_Node_attributes():

--- a/cf_units/tests/integration/parse/test_parse.py
+++ b/cf_units/tests/integration/parse/test_parse.py
@@ -167,9 +167,7 @@ def test_invalid_units(_, unit_str):
         cf_valid = False
 
     # Double check that udunits2 can't parse this.
-    assert (
-        cf_valid is False
-    ), "Unit {!r} is unexpectedly valid in UDUNITS2".format(unit_str)
+    assert cf_valid is False, f"Unit {unit_str!r} is unexpectedly valid in UDUNITS2"
 
     try:
         normalize(unit_str)
@@ -178,7 +176,7 @@ def test_invalid_units(_, unit_str):
         can_parse = False
 
     # Now confirm that we couldn't parse this either.
-    msg = "Parser unexpectedly able to deal with {}".format(unit_str)
+    msg = f"Parser unexpectedly able to deal with {unit_str}"
     assert can_parse is False, msg
 
 
@@ -234,15 +232,13 @@ known_issues = [
 ]
 
 
-@pytest.mark.parametrize(
-    "_, unit_str, expected", multi_enumerate(known_issues)
-)
+@pytest.mark.parametrize("_, unit_str, expected", multi_enumerate(known_issues))
 def test_known_issues(_, unit_str, expected):
     # Unfortunately the grammar is not perfect.
     # These are the cases that don't work yet but which do work with udunits.
 
     # Make sure udunits can read it.
-    cf_units.Unit(unit_str).symbol
+    cf_units.Unit(unit_str).symbol  # noqa: B018
 
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(SyntaxError):
@@ -293,7 +289,7 @@ def test_invalid_syntax_units(_, unit_str):
     # allowed with our grammar.
 
     with pytest.raises(ValueError):
-        cf_units.Unit(unit_str).symbol
+        cf_units.Unit(unit_str).symbol  # noqa: B018
 
     with pytest.raises(SyntaxError):
         normalize(unit_str)

--- a/cf_units/tests/integration/test__num2date_to_nearest_second.py
+++ b/cf_units/tests/integration/test__num2date_to_nearest_second.py
@@ -253,9 +253,7 @@ class Test:
 
     def test_pydatetime_wrong_calendar(self):
         unit = cf_units.Unit("days since 1970-01-01", calendar="360_day")
-        with pytest.raises(
-            ValueError, match="illegal calendar or reference date"
-        ):
+        with pytest.raises(ValueError, match="illegal calendar or reference date"):
             _num2date_to_nearest_second(
                 1,
                 unit,

--- a/cf_units/tests/integration/test_num2date.py
+++ b/cf_units/tests/integration/test_num2date.py
@@ -12,9 +12,7 @@ from cf_units import num2date
 
 class Test:
     def test_num2date_wrong_calendar(self):
-        with pytest.raises(
-            ValueError, match="illegal calendar or reference date"
-        ):
+        with pytest.raises(ValueError, match="illegal calendar or reference date"):
             num2date(
                 1,
                 "days since 1970-01-01",

--- a/cf_units/tests/integration/test_num2pydate.py
+++ b/cf_units/tests/integration/test_num2pydate.py
@@ -19,7 +19,5 @@ class Test:
         assert isinstance(result, datetime.datetime)
 
     def test_num2pydate_wrong_calendar(self):
-        with pytest.raises(
-            ValueError, match="illegal calendar or reference date"
-        ):
+        with pytest.raises(ValueError, match="illegal calendar or reference date"):
             num2pydate(1, "days since 1970-01-01", calendar="360_day")

--- a/cf_units/tests/test_coding_standards.py
+++ b/cf_units/tests/test_coding_standards.py
@@ -3,11 +3,11 @@
 # This file is part of cf-units and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
 
-import os
-import subprocess
 from datetime import datetime
 from fnmatch import fnmatch
 from glob import glob
+import os
+import subprocess
 
 import pytest
 
@@ -28,9 +28,7 @@ DOCS_DIR = cf_units.config.get_option("Resources", "doc_dir", default=DOCS_DIR)
 exclusion = ["Makefile", "make.bat", "build"]
 DOCS_DIRS = glob(os.path.join(DOCS_DIR, "*"))
 DOCS_DIRS = [
-    DOC_DIR
-    for DOC_DIR in DOCS_DIRS
-    if os.path.basename(DOC_DIR) not in exclusion
+    DOC_DIR for DOC_DIR in DOCS_DIRS if os.path.basename(DOC_DIR) not in exclusion
 ]
 
 
@@ -75,7 +73,7 @@ class TestLicenseHeaders:
         """
         # Check the ".git" folder exists at the repo dir.
         if not os.path.isdir(os.path.join(REPO_DIR, ".git")):
-            raise ValueError("{} is not a git repository.".format(REPO_DIR))
+            raise ValueError(f"{REPO_DIR} is not a git repository.")
 
         # Call "git whatchanged" to get the details of all the files and when
         # they were last changed.
@@ -104,12 +102,10 @@ class TestLicenseHeaders:
             last_change_by_fname = self.last_change_by_fname()
         except ValueError:
             # Caught the case where this is not a git repo.
-            return pytest.skip(
-                "cf_units installation did not look like a " "git repo."
-            )
+            return pytest.skip("cf_units installation did not look like a " "git repo.")
 
         failed = False
-        for fname, last_change in sorted(last_change_by_fname.items()):
+        for fname, _last_change in sorted(last_change_by_fname.items()):
             full_fname = os.path.join(REPO_DIR, fname)
             if (
                 full_fname.endswith(".py")
@@ -126,6 +122,4 @@ class TestLicenseHeaders:
                         failed = True
 
         if failed:
-            raise AssertionError(
-                "There were license header failures. See stdout."
-            )
+            raise AssertionError("There were license header failures. See stdout.")

--- a/cf_units/tests/test_unit.py
+++ b/cf_units/tests/test_unit.py
@@ -10,8 +10,8 @@ Test Unit the wrapper class for Unidata udunits2.
 import copy
 import datetime as datetime
 import operator
-import re
 from operator import truediv
+import re
 
 import cftime
 import numpy as np
@@ -164,9 +164,7 @@ class Test_format:
     def test_format_multiple_options_utf8(self):
         u = Unit("watt")
         assert (
-            u.format(
-                [cf_units.UT_NAMES, cf_units.UT_DEFINITION, cf_units.UT_UTF8]
-            )
+            u.format([cf_units.UT_NAMES, cf_units.UT_DEFINITION, cf_units.UT_UTF8])
             == "meter²·kilogram·second⁻³"
         )
 
@@ -833,7 +831,7 @@ class Test_title:
 class Test__immutable:
     def _set_attr(self, unit, name):
         setattr(unit, name, -999)
-        raise ValueError("'Unit' attribute {!r} is mutable!".format(name))
+        raise ValueError(f"'Unit' attribute {name!r} is mutable!")
 
     def test_immutable(self):
         u = Unit("m")
@@ -889,9 +887,7 @@ class Test__inplace:
 
         # Manufacture a Fortran-ordered nd array to be converted.
         orig = (
-            np.ma.masked_array(
-                np.arange(4, dtype=np.float32), mask=[1, 0, 0, 1]
-            )
+            np.ma.masked_array(np.arange(4, dtype=np.float32), mask=[1, 0, 0, 1])
             .reshape([2, 2])
             .T
         )
@@ -971,9 +967,7 @@ class TestNumsAndDates:
             "hours since 2010-11-02 12:00:00",
             calendar=cf_units.CALENDAR_360_DAY,
         )
-        with pytest.raises(
-            ValueError, match="illegal calendar or reference date"
-        ):
+        with pytest.raises(ValueError, match="illegal calendar or reference date"):
             u.num2date(
                 1,
                 only_use_cftime_datetimes=False,
@@ -1003,9 +997,7 @@ class TestNumsAndDates:
             "hours since 2010-11-02 12:00:00",
             calendar=cf_units.CALENDAR_360_DAY,
         )
-        with pytest.raises(
-            ValueError, match="illegal calendar or reference date"
-        ):
+        with pytest.raises(ValueError, match="illegal calendar or reference date"):
             u.num2pydate(1)
 
 

--- a/cf_units/tests/unit/test__discard_microsecond.py
+++ b/cf_units/tests/unit/test__discard_microsecond.py
@@ -15,7 +15,14 @@ from cf_units import _discard_microsecond as discard_microsecond
 
 class Test__datetime:
     def setup_method(self):
-        self.kwargs = dict(year=1, month=2, day=3, hour=4, minute=5, second=6)
+        self.kwargs = {
+            "year": 1,
+            "month": 2,
+            "day": 3,
+            "hour": 4,
+            "minute": 5,
+            "second": 6,
+        }
         self.expected = datetime.datetime(**self.kwargs, microsecond=0)
 
     def test_single(self):
@@ -37,16 +44,21 @@ class Test__datetime:
 
 class Test__cftime:
     def setup_method(self):
-        self.kwargs = dict(year=1, month=2, day=3, hour=4, minute=5, second=6)
+        self.kwargs = {
+            "year": 1,
+            "month": 2,
+            "day": 3,
+            "hour": 4,
+            "minute": 5,
+            "second": 6,
+        }
         self.calendars = cftime._cftime._calendars
 
     def test_single(self):
         for calendar in self.calendars:
             dt = cftime.datetime(**self.kwargs, calendar=calendar)
             actual = discard_microsecond(dt)
-            expected = cftime.datetime(
-                **self.kwargs, microsecond=0, calendar=calendar
-            )
+            expected = cftime.datetime(**self.kwargs, microsecond=0, calendar=calendar)
             assert expected == actual
 
     def test_multi(self):
@@ -55,34 +67,31 @@ class Test__cftime:
 
         for calendar in self.calendars:
             dates = np.array(
-                [
-                    cftime.datetime(**self.kwargs, calendar=calendar)
-                    for i in range(n)
-                ]
+                [cftime.datetime(**self.kwargs, calendar=calendar) for i in range(n)]
             ).reshape(shape)
             actual = discard_microsecond(dates)
             expected = np.array(
-                [
-                    cftime.datetime(
-                        **self.kwargs, microsecond=0, calendar=calendar
-                    )
-                ]
-                * n
+                [cftime.datetime(**self.kwargs, microsecond=0, calendar=calendar)] * n
             ).reshape(shape)
             np.testing.assert_array_equal(expected, actual)
 
 
 class Test__falsy:
     def setup_method(self):
-        self.kwargs = dict(year=1, month=2, day=3, hour=4, minute=5, second=6)
+        self.kwargs = {
+            "year": 1,
+            "month": 2,
+            "day": 3,
+            "hour": 4,
+            "minute": 5,
+            "second": 6,
+        }
         self.calendar = "360_day"
         microsecond = 7
         self.cftime = cftime.datetime(
             **self.kwargs, microsecond=microsecond, calendar=self.calendar
         )
-        self.datetime = datetime.datetime(
-            **self.kwargs, microsecond=microsecond
-        )
+        self.datetime = datetime.datetime(**self.kwargs, microsecond=microsecond)
 
     def test_single__none(self):
         assert discard_microsecond(None) is None

--- a/cf_units/tests/unit/test__udunits2.py
+++ b/cf_units/tests/unit/test__udunits2.py
@@ -77,9 +77,7 @@ class Test_system:
         assert angstrom is not None
 
     def test_parse_UTF8(self):
-        angstrom = _ud.parse(
-            self.system, b"\xc3\xa5ngstr\xc3\xb6m", _ud.UT_UTF8
-        )
+        angstrom = _ud.parse(self.system, b"\xc3\xa5ngstr\xc3\xb6m", _ud.UT_UTF8)
 
         assert angstrom is not None
 
@@ -222,9 +220,7 @@ class Test_time_encoding:
         assert self.date_encoding == res_date_encoding
 
     def test_encode_clock(self):
-        res_clock_encoding = _ud.encode_clock(
-            self.hours, self.minutes, self.seconds
-        )
+        res_clock_encoding = _ud.encode_clock(self.hours, self.minutes, self.seconds)
 
         assert self.clock_encoding == res_clock_encoding
 
@@ -259,9 +255,7 @@ class Test_time_encoding:
             self.minutes,
         )
         assert (
-            res_seconds - res_resolution
-            < self.seconds
-            < res_seconds + res_resolution
+            res_seconds - res_resolution < self.seconds < res_seconds + res_resolution
         )
 
 

--- a/cf_units/tests/unit/unit/test_Unit.py
+++ b/cf_units/tests/unit/unit/test_Unit.py
@@ -218,9 +218,7 @@ class Test_convert__result_ctype:
 
     def setup_method(self):
         self.initial_dtype = np.float32
-        self.degs_array = np.array(
-            [356.7, 356.8, 356.9], dtype=self.initial_dtype
-        )
+        self.degs_array = np.array([356.7, 356.8, 356.9], dtype=self.initial_dtype)
         self.deg = cf_units.Unit("degrees")
         self.rad = cf_units.Unit("radians")
 
@@ -260,15 +258,11 @@ class Test_convert__masked_array:
         )
 
     def test_no_type_conversion(self):
-        result = self.deg.convert(
-            self.degs_array, self.rad, ctype=cf_units.FLOAT32
-        )
+        result = self.deg.convert(self.degs_array, self.rad, ctype=cf_units.FLOAT32)
         np.testing.assert_array_almost_equal(self.rads_array, result)
 
     def test_type_conversion(self):
-        result = self.deg.convert(
-            self.degs_array, self.rad, ctype=cf_units.FLOAT64
-        )
+        result = self.deg.convert(self.degs_array, self.rad, ctype=cf_units.FLOAT64)
         np.testing.assert_array_almost_equal(self.rads_array, result)
 
 

--- a/cf_units/tests/unit/unit/test_as_unit.py
+++ b/cf_units/tests/unit/unit/test_as_unit.py
@@ -9,7 +9,7 @@ import copy
 from cf_units import Unit, as_unit
 
 
-class StubUnit(object):
+class StubUnit:
     def __init__(self, calendar=None):
         self.calendar = str(calendar) if calendar is not None else None
         # udunit category

--- a/cf_units/tex.py
+++ b/cf_units/tex.py
@@ -3,8 +3,8 @@
 # This file is part of cf-units and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
 
-import cf_units._udunits2_parser.graph as graph  # noqa: E402
 from cf_units._udunits2_parser import parse as _parse  # noqa: E402
+import cf_units._udunits2_parser.graph as graph  # noqa: E402
 
 
 class TeXVisitor(graph.Visitor):

--- a/cf_units/util.py
+++ b/cf_units/util.py
@@ -8,8 +8,8 @@ Miscellaneous utility functions.
 """
 
 import abc
-import warnings
 from collections.abc import Hashable
+import warnings
 
 
 def approx_equal(a, b, max_absolute_error=1e-10, max_relative_error=1e-10):
@@ -64,8 +64,8 @@ class _MetaOrderedHashable(abc.ABCMeta):
             if "__init__" not in namespace:
                 # Create a default __init__ method for the class
                 method_source = (
-                    "def __init__(self, %s):\n "
-                    "self._init_from_tuple((%s,))" % (args, args)
+                    "def __init__(self, {}):\n "
+                    "self._init_from_tuple(({},))".format(args, args)
                 )
                 exec(method_source, namespace)
 
@@ -74,14 +74,12 @@ class _MetaOrderedHashable(abc.ABCMeta):
             if "_init" not in namespace:
                 # Create a default _init method for the class
                 method_source = (
-                    "def _init(self, %s):\n "
-                    "self._init_from_tuple((%s,))" % (args, args)
+                    "def _init(self, {}):\n "
+                    "self._init_from_tuple(({},))".format(args, args)
                 )
                 exec(method_source, namespace)
 
-        return super(_MetaOrderedHashable, cls).__new__(
-            cls, name, bases, namespace
-        )
+        return super().__new__(cls, name, bases, namespace)
 
 
 class _OrderedHashable(Hashable, metaclass=_MetaOrderedHashable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,30 +46,36 @@ write_to = "cf_units/_version.py"
 local_scheme = "dirty-tag"
 
 [tool.black]
-line-length = 79
-target-version = ["py38", "py39", "py310"]
+line-length = 88
+target-version = ["py38", "py39", "py310", "py311"]
 include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-  | _version.py
-)
-'''
 
-[tool.isort]
-known_first_party = "cf_units"
-line_length = 79
-profile = "black"
-skip_gitignore = "True"
-verbose = "False"
+[tool.ruff]
+line-length = 88
+target-version = "py38"
+select = [
+    # pyflakes
+    "F",
+    # pycodestyle
+    "E",
+    "W",
+    # flake8-bugbear
+    "B",
+    # flake8-comprehensions
+    "C4",
+    # isort
+    "I",
+    # pyupgrade
+    "UP",
+]
+ignore = ["B904", "F403", "F405"]
+
+[tool.ruff.isort]
+force-sort-within-sections = true
+known-first-party = ["cf_units"]
+
+[tool.ruff.mccabe]
+max-complexity = 22
+
+[tool.ruff.pydocstyle]
+convention = "numpy"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-import sys
 from distutils.sysconfig import get_config_var
 from os import environ
 from pathlib import Path
 from shutil import copy
+import sys
 
 from setuptools import Command, Extension, setup
 
@@ -134,9 +134,7 @@ udunits_ext = Extension(
     library_dirs=library_dirs,
     libraries=["udunits2"],
     define_macros=DEFINE_MACROS,
-    runtime_library_dirs=None
-    if sys.platform.startswith("win")
-    else library_dirs,
+    runtime_library_dirs=None if sys.platform.startswith("win") else library_dirs,
 )
 
 if cythonize:
@@ -146,10 +144,10 @@ if cythonize:
 
 cmdclass = {"clean_cython": CleanCython, "build_ext": numpy_build_ext}
 
-kwargs = dict(
-    cmdclass=cmdclass,
-    ext_modules=[udunits_ext],
-    package_data=get_package_data(),
-)
+kwargs = {
+    "cmdclass": cmdclass,
+    "ext_modules": [udunits_ext],
+    "package_data": get_package_data(),
+}
 
 setup(**kwargs)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR adopts [ruff](https://github.com/charliermarsh/ruff) and drops the explicit use of `isort` and `flake8`.

Running `ruff` across the codebase rediscovers a whole collections of exceptions that clearly have been missed for `flake8` et al compliance.

- [ ] Once #352 is merged, then I'll rebase and add the `ruff` badge.