### PR TITLE
pin tox

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -70,7 +70,7 @@ jobs:
     - name: "Conda environment update"
       if: steps.conda-env-cache.outputs.cache-hit != 'true'
       run: |
-        conda install --name ${{ env.ENV_NAME }} tox
+        conda install --name ${{ env.ENV_NAME }} "tox<4"
 
     - name: "Conda info"
       run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -85,7 +85,7 @@ jobs:
     - name: "Conda environment update"
       if: steps.conda-env-cache.outputs.cache-hit != 'true'
       run: |
-        conda install --name ${{ env.ENV_NAME }} tox
+        conda install --name ${{ env.ENV_NAME }} "tox<4"
 
     - name: "Conda info"
       run: |


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
The PR pins back `tox` as the `tox-conda` plugin is not yet compatible with `tox>=4` :cry: 

Reference https://github.com/tox-dev/tox-conda/issues/156