### PR TITLE
explicitly set cython language_level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,9 @@ udunits_ext = Extension(
 
 if cythonize:
     [udunits_ext] = cythonize(
-        udunits_ext, compiler_directives=COMPILER_DIRECTIVES, language_level=2
+        udunits_ext,
+        compiler_directives=COMPILER_DIRECTIVES,
+        language_level="3str",
     )
 
 cmdclass = {"clean_cython": CleanCython, "build_ext": numpy_build_ext}


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR explicitly sets the `cython` `language_level` compiler directive to be the forthcoming default of `3str` when v3.0.0 is available.

Reference:
- https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html?highlight=language_level#compiler-directives
- https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html?highlight=language_level