### PR TITLE
nep29 drop numpy 1.22

### DIFF
--- a/requirements/cf-units.yml
+++ b/requirements/cf-units.yml
@@ -13,7 +13,7 @@ dependencies:
 # core dependencies
   - antlr-python-runtime 4.11.1.*  # To update this, see cf_units/_udunits2_parser/README.md
   - cftime>=1.2
-  - numpy
+  - numpy>=1.23
   - udunits2
 
 # test dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     antlr4-python3-runtime ==4.11.1  # To update this, see cf_units/_udunits2_parser/README.md
     cftime >=1.2
     jinja2
-    numpy
+    numpy >=1.23
     # udunits2 cannot be installed with pip, and it is expected to be
     #  installed separately.
 packages = find_namespace:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces `nep29` and drops `numpy 1.22`, as scheduled.

See [NEP29 Drop Schedule](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule).