### PR TITLE
Update ci-wheels.yml for cibuildwheel v2.16.5

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -61,8 +61,6 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BEFORE_BUILD_LINUX: yum install -y udunits2-devel
         CIBW_BEFORE_BUILD_MACOS: brew install udunits
-        # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-        CIBW_TEST_SKIP: "*_arm64"
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: >
           python -c 'import cf_units; print(f"cf-units v{cf_units.__version__}")' &&


### PR DESCRIPTION
Try testing bdist of cross-compilation for `macos` `arm64` on `x86_64`, given the latest release of `cibuildwheels` [v2.16.5](https://github.com/pypa/cibuildwheel/releases/tag/v2.16.5)

## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
