### PR TITLE
Update ci-wheels.yml for cibuildwheel v2.16.5

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,8 +40,8 @@ jobs:
             version: py311
             posargs: "--cov-report=xml --cov"
             post-command: codecov
-          - version: py311
-            os: macos-latest
+          - os: macos-latest
+            version: py311
             platform: osx
     steps:
     - name: "Checkout"

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -27,25 +27,28 @@ concurrency:
 jobs:
   build_bdist:
     name: "Build ${{ matrix.os }} (${{ matrix.arch }}) wheels"
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # TBD: extend to support windows
-        os: ["ubuntu", "macos"]
-        arch: ["x86_64", "arm64"]
-        exclude:
-        - os: ubuntu
-          arch: arm64
+        os: ["ubuntu-latest", "macos-11", "macos-14"]
         include:
-        - os: ubuntu
+        - os: ubuntu-latest
+          arch: x86_64
           incdir: /usr/include/udunits2
           libdir: /usr/lib64
           xml_path: /usr/share/udunits/udunits2.xml
-        - os: macos
+        - os: macos-11
+          arch: x86_64
           incdir: /usr/local/Cellar/udunits/2.2.28/include
           libdir: /usr/local/Cellar/udunits/2.2.28/lib
           xml_path: /usr/local/Cellar/udunits/2.2.28/share/udunits/udunits2-common.xml
+        - os: macos-14
+          arch: arm64
+          incdir: /opt/homebrew/Cellar/udunits/2.2.28/include
+          libdir: /opt/homebrew/Cellar/udunits/2.2.28/lib
+          xml_path: /opt/homebrew/Cellar/udunits/2.2.28/share/udunits/udunits2-common.xml
 
     steps:
     - uses: actions/checkout@v4
@@ -61,8 +64,6 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BEFORE_BUILD_LINUX: yum install -y udunits2-devel
         CIBW_BEFORE_BUILD_MACOS: brew install udunits
-        # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-        CIBW_TEST_SKIP: "*_arm64"
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: >
           python -c 'import cf_units; print(f"cf-units v{cf_units.__version__}")' &&


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Try testing native `arm64` using `macos-14` GHA runner, given the latest release of `cibuildwheels` [v2.16.5](https://github.com/pypa/cibuildwheel/releases/tag/v2.16.5)

So we now have build, install and test bdist natively with no cross-compilation:

- use `ubuntu` for `x86_64` wheels
- use `macos-11` for `x86_64` wheels 
- use `macos-14` for `arm64` wheels