### PR TITLE
Fix for bad git path in GHA macos instances.

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         version: [py310, py311]
+        gitpath-prepend: [""]
         include:
           - os: ubuntu-latest
             platform: linux
@@ -43,6 +44,9 @@ jobs:
           - os: macos-latest
             version: py311
             platform: osx
+            # On macos, the up-to-date git may not be first on the path
+            # N.B. setting includes a final ":", to simplify the path setting command
+            gitpath-prepend: "/opt/homebrew/bin:"
     steps:
     - name: "Checkout"
       uses: actions/checkout@v4
@@ -108,4 +112,7 @@ jobs:
       env:
         POST_COMMAND: ${{ matrix.post-command }}
       run: |
+        export PATH=${{ matrix.gitpath-prepend }}$PATH
+        which git
+        git --version
         tox -e ${{ matrix.version }}-${{ matrix.platform }}-test -- ${{ matrix.posargs }}


### PR DESCRIPTION
From testing problems in #458 and #460, there is an odd problem with GHA macos instances
  - apparently intermittent ?
  - [this discussion](https://github.com/actions/runner-images/issues/10624#issuecomment-2358927041) probably relates
    (this might also indicate that the root problem may soon get [a fix](https://github.com/actions/runner-images/pull/10647)?)

In detail, it seems that the latest-good git installation is not (?always?) put on the front of the path when your GHA runs,
but instead an older system git runs by default.  Which, possibly, does not have a "git version" command ?

So, for now, this hack pushes a magic directory onto the front of PATH to make the tests run.

(N.B. wheels are OK and unaffected.  The problem occurs when doing an editable install of the repo)