### PR TITLE
Fixlocks

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/cache@v4.0.2
       env:
         # Increment the build number to force a cache refresh.
-        CACHE_BUILD: 2
+        CACHE_BUILD: 5
       with:
         path: ~/conda_pkgs_dir
         key: ${{ runner.os }}-conda-pkgs-${{ env.ENV_NAME }}-p${{ env.CACHE_PERIOD }}-b${{ env.CACHE_BUILD }}
@@ -52,17 +52,16 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
-        channels: conda-forge,defaults
+        channels: conda-forge
         activate-environment: ${{ env.ENV_NAME }}
         auto-update-conda: true
-        use-only-tar-bz2: true
 
     - name: "Conda environment cache"
       id: conda-env-cache
       uses: actions/cache@v4.0.2
       env:
         # Increment the build number to force a cache refresh.
-        CACHE_BUILD: 2
+        CACHE_BUILD: 5
       with:
         path: ${{ env.CONDA }}/envs/${{ env.ENV_NAME }}
         key: ${{ runner.os }}-conda-env-${{ env.ENV_NAME }}-p${{ env.CACHE_PERIOD }}-b${{ env.CACHE_BUILD }}
@@ -81,7 +80,7 @@ jobs:
       uses: actions/cache@v4.0.2
       env:
         # Increment the build number to forece a cache refresh.
-        CACHE_BUILD: 2
+        CACHE_BUILD: 5
         TOX_INI: ${{ github.workspace }}/tox.ini
       with:
         path: ${{ github.workspace }}/.tox

--- a/requirements/cf-units.yml
+++ b/requirements/cf-units.yml
@@ -13,7 +13,7 @@ dependencies:
 # core dependencies
   - antlr-python-runtime 4.11.1.*  # To update this, see cf_units/_udunits2_parser/README.md
   - cftime>=1.2
-  - numpy==1.26.4
+  - numpy<2
   - udunits2
 
 # test dependencies


### PR DESCRIPTION
Addresses #466

From the actions panel, it appears that the lockfile updates were successfully occurring with the previous py39/py310/py311 version.
But this broke for python 3.12 versions, when python versions were updated.

**Also** ... Prior to the Python version update, the lockfiles update action seemed to be working, but did not generate PRs as expected.
It may be simply that the target branch "" had been removed, and the actions have permission to update that, but not to (re-)create it.  We will check that subsequently ...
