### PR TITLE
Pin numpy to v1, but no tighter.

### DIFF
--- a/requirements/cf-units.yml
+++ b/requirements/cf-units.yml
@@ -13,7 +13,7 @@ dependencies:
 # core dependencies
   - antlr-python-runtime 4.11.1.*  # To update this, see cf_units/_udunits2_parser/README.md
   - cftime>=1.2
-  - numpy==1.26.4
+  - numpy<1.99
   - udunits2
 
 # test dependencies

--- a/requirements/cf-units.yml
+++ b/requirements/cf-units.yml
@@ -13,7 +13,7 @@ dependencies:
 # core dependencies
   - antlr-python-runtime 4.11.1.*  # To update this, see cf_units/_udunits2_parser/README.md
   - cftime>=1.2
-  - numpy<1.99
+  - numpy<2
   - udunits2
 
 # test dependencies


### PR DESCRIPTION
I think pinning numpy to exactly 1.26.4 was probably an oversight, introduced with #455