### PR TITLE
Use unshallow Git fetch for setuptools-scm (Read the Docs)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,9 @@ build:
     python: mambaforge-4.10
   jobs:
     post_checkout:
+      # The SciTools/cf-units repository is shallow i.e., has a .git/shallow,
+      # therefore complete the repository with a full history in order
+      # to allow setuptools-scm to correctly auto-discover the version.
       - git fetch --unshallow
       - git fetch --all
     pre_install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,7 @@ build:
     python: mambaforge-4.10
   jobs:
     post_checkout:
-      # reference: https://github.com/SciTools/cf-units/pull/272
-      # perform a "git fetch --unshallow" when the cf-units repo
-      # becomes incomplete i.e., there is a .git/shallow.
+      - git fetch --unshallow
       - git fetch --all
     pre_install:
       # create a "common" link to the underlying rtd conda environment,


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

@pp-mo was right - there is an issue with the information setuptools_scm is getting when running on Read the Docs. Clearly a gap in my knowledge there, sorry!

Adding the same `git fetch --unshallow` that Iris has seems to fix the issue - can see that the RTD build on this PR has a correct version, whereas the current `main` does not.
