### PR TITLE
Artifact Actions v4

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -91,7 +91,7 @@ jobs:
         tox -e ${{ matrix.lock }} -- --platform osx-64 --platform win-64
 
     - name: "Upload lock artifacts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
         name: lock-artifacts
         path: ${{ github.workspace }}/requirements/locks/${{ matrix.lock }}*.txt
@@ -106,7 +106,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: "Download lock artifacts"
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         name: lock-artifacts
         path: ${{ github.workspace }}/requirements/locks

--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -91,7 +91,7 @@ jobs:
         tox -e ${{ matrix.lock }} -- --platform osx-64 --platform win-64
 
     - name: "Upload lock artifacts"
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@v4.4.0
       with:
         name: lock-artifacts
         path: ${{ github.workspace }}/requirements/locks/${{ matrix.lock }}*.txt
@@ -106,7 +106,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: "Download lock artifacts"
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      uses: actions/download-artifact@v4.1.7
       with:
         name: lock-artifacts
         path: ${{ github.workspace }}/requirements/locks

--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -91,7 +91,7 @@ jobs:
         tox -e ${{ matrix.lock }} -- --platform osx-64 --platform win-64
 
     - name: "Upload lock artifacts"
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: lock-artifacts
         path: ${{ github.workspace }}/requirements/locks/${{ matrix.lock }}*.txt
@@ -106,7 +106,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: "Download lock artifacts"
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: lock-artifacts
         path: ${{ github.workspace }}/requirements/locks

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -87,7 +87,7 @@ jobs:
         UDUNITS2_XML_PATH: ${{ matrix.xml_path }}
         CIBW_ENVIRONMENT_PASS_LINUX: UDUNITS2_INCDIR UDUNITS2_LIBDIR UDUNITS2_XML_PATH
 
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+    - uses: actions/upload-artifact@v4.4.0
       with:
         name: pypi-artifacts-bdist
         path: ${{ github.workspace }}/wheelhouse/*.whl
@@ -106,7 +106,7 @@ jobs:
       run: |
         pipx run build --sdist 
 
-    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+    - uses: actions/upload-artifact@v4.4.0
       with:
         name: pypi-artifacts-sdist
         path: ${{ github.workspace }}/dist/*.tar.gz
@@ -117,7 +117,7 @@ jobs:
     name: "Show artifacts"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+    - uses: actions/download-artifact@v4.1.7
       with:
         path: ${{ github.workspace }}/dist
 
@@ -133,7 +133,7 @@ jobs:
     # upload to Test PyPI for every commit on main branch
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+    - uses: actions/download-artifact@v4.1.7
       with:
         path: ${{ github.workspace }}/dist
 
@@ -153,7 +153,7 @@ jobs:
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+    - uses: actions/download-artifact@v4.1.7
       with:
         path: ${{ github.workspace }}/dist
 

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -89,7 +89,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: pypi-artifacts-bdist
+        name: pypi-artifacts-bdist-${{ matrix.os }}-${{ matrix.arch }}
         path: ${{ github.workspace }}/wheelhouse/*.whl
 
 

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -120,6 +120,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         path: ${{ github.workspace }}/dist
+        merge-multiple: true
 
     - shell: bash
       run: |
@@ -136,6 +137,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         path: ${{ github.workspace }}/dist
+        merge-multiple: true
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -156,6 +158,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         path: ${{ github.workspace }}/dist
+        merge-multiple: true
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -87,7 +87,7 @@ jobs:
         UDUNITS2_XML_PATH: ${{ matrix.xml_path }}
         CIBW_ENVIRONMENT_PASS_LINUX: UDUNITS2_INCDIR UDUNITS2_LIBDIR UDUNITS2_XML_PATH
 
-    - uses: actions/upload-artifact@v4.4.0
+    - uses: actions/upload-artifact@v4
       with:
         name: pypi-artifacts-bdist
         path: ${{ github.workspace }}/wheelhouse/*.whl
@@ -106,7 +106,7 @@ jobs:
       run: |
         pipx run build --sdist 
 
-    - uses: actions/upload-artifact@v4.4.0
+    - uses: actions/upload-artifact@v4
       with:
         name: pypi-artifacts-sdist
         path: ${{ github.workspace }}/dist/*.tar.gz
@@ -117,7 +117,7 @@ jobs:
     name: "Show artifacts"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v4.1.7
+    - uses: actions/download-artifact@v4
       with:
         path: ${{ github.workspace }}/dist
 
@@ -133,7 +133,7 @@ jobs:
     # upload to Test PyPI for every commit on main branch
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
-    - uses: actions/download-artifact@v4.1.7
+    - uses: actions/download-artifact@v4
       with:
         path: ${{ github.workspace }}/dist
 
@@ -153,7 +153,7 @@ jobs:
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-    - uses: actions/download-artifact@v4.1.7
+    - uses: actions/download-artifact@v4
       with:
         path: ${{ github.workspace }}/dist
 

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -87,7 +87,7 @@ jobs:
         UDUNITS2_XML_PATH: ${{ matrix.xml_path }}
         CIBW_ENVIRONMENT_PASS_LINUX: UDUNITS2_INCDIR UDUNITS2_LIBDIR UDUNITS2_XML_PATH
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
         name: pypi-artifacts-bdist
         path: ${{ github.workspace }}/wheelhouse/*.whl
@@ -106,7 +106,7 @@ jobs:
       run: |
         pipx run build --sdist 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
         name: pypi-artifacts-sdist
         path: ${{ github.workspace }}/dist/*.tar.gz
@@ -117,7 +117,7 @@ jobs:
     name: "Show artifacts"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         path: ${{ github.workspace }}/dist
 
@@ -133,7 +133,7 @@ jobs:
     # upload to Test PyPI for every commit on main branch
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         path: ${{ github.workspace }}/dist
 
@@ -153,7 +153,7 @@ jobs:
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         path: ${{ github.workspace }}/dist
 

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -89,7 +89,7 @@ jobs:
 
     - uses: actions/upload-artifact@v3
       with:
-        name: pypi-artifacts
+        name: pypi-artifacts-bdist
         path: ${{ github.workspace }}/wheelhouse/*.whl
 
 
@@ -108,7 +108,7 @@ jobs:
 
     - uses: actions/upload-artifact@v3
       with:
-        name: pypi-artifacts
+        name: pypi-artifacts-sdist
         path: ${{ github.workspace }}/dist/*.tar.gz
 
 
@@ -119,7 +119,6 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: pypi-artifacts
         path: ${{ github.workspace }}/dist
 
     - shell: bash
@@ -136,7 +135,6 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: pypi-artifacts
         path: ${{ github.workspace }}/dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1
@@ -157,7 +155,6 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: pypi-artifacts
         path: ${{ github.workspace }}/dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Attempt to make the cf-units GitHub Actions compatible with the version 4 [artifact actions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow) (which do not allow duplicate-named artifacts).

Closes #442 