### PR TITLE
[cf-units] Repo review updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       day: "thursday"
       time: "01:00"
       timezone: "Europe/London"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     labels:
       - "New: Pull Request"
       - "Bot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,11 +244,10 @@ convention = "numpy"
 ignore = [
     # TODO: exceptions that still need investigating are below.
     # Might be fixable, or might become permanent (above):
-    "GH212",  # Require GHA update grouping
     "MY105",  # MyPy enables redundant-expr  (TODO: see MyPy ignore below)
     "PC170",  # Uses PyGrep hooks (only needed if rST present)
     "PC180",  # Uses a markdown formatter
-    "PY005",  # Has tests folder
+    "PY005",  # Has tests folder (TODO: it does, but not in standard location)
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@
 requires = [
   "setuptools>=45",
   "setuptools_scm[toml]>=7.0",
-  "wheel",
   "numpy",
   "Cython>=3.0",
 ]
@@ -249,7 +248,6 @@ ignore = [
     "MY105",  # MyPy enables redundant-expr  (TODO: see MyPy ignore below)
     "PC170",  # Uses PyGrep hooks (only needed if rST present)
     "PC180",  # Uses a markdown formatter
-    "PP003",  # Does not list wheel as a build-dep
     "PY005",  # Has tests folder
 ]
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
A couple of quick fixes to the sp-repo-review checks:
  - Adds GHA update grouping for dependabot (GH212)
  - Removes `wheel` from build (PP003)
