### PR TITLE
pep639: setuptools license and license-files fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@
 build-backend = "setuptools.build_meta"
 # Defined by PEP 518
 requires = [
-    "setuptools>=45",
-    "setuptools_scm[toml]>=7.0",
+    "setuptools>=77.0.3",
+    "setuptools_scm[toml]>=8.0",
     "numpy",
     "Cython>=3.0",
 ]
@@ -18,7 +18,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
@@ -55,7 +54,8 @@ keywords = [
 name = "cf-units"
 readme = "README.md"
 requires-python = ">=3.10"
-license.file = "LICENSE"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 
 [project.optional-dependencies]
 all = ["cf-units[docs,test]"]

--- a/requirements/cf-units.yml
+++ b/requirements/cf-units.yml
@@ -5,8 +5,8 @@ channels:
 
 dependencies:
 # setup dependencies
-  - setuptools >=45
-  - setuptools_scm >=7.0
+  - setuptools >=77.0.3
+  - setuptools_scm >=8.0
   - cython >=3.0
   - numpy
 


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request mops up some tech debt to comply with [PEP639](https://peps.python.org/pep-0639/) for `setuptools`, also see [license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

Additionally avoids the following `setuptools` deprecation warning:
```
!!
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:
          License :: OSI Approved :: BSD License
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
!!
```
See [Deprecated license classifiers](https://peps.python.org/pep-0639/#deprecate-license-classifiers).