### PR TITLE
Fix macos builds.

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: "Set MACOSX_DEPLOYMENT_TARGET"
       if: startsWith(matrix.os, 'macos')
-      run: echo "MACOSX_DEPLOYMENT_TARGET=$([[ ${{ matrix.os }} == 'macos-latest' ]] && echo '14.0' || echo '13.0')" >> $GITHUB_ENV
+      run: echo "MACOSX_DEPLOYMENT_TARGET=$([[ ${{ matrix.os }} == 'macos-latest' ]] && echo '15.0' || echo '13.0')" >> $GITHUB_ENV
 
 
     - name: "Conda install"


### PR DESCRIPTION
From current wheels-build failures  (e.g. #620), we note that "macos-latest" is now at v15.0.
E.G. properties described [here](https://github.com/actions/runner-images/tree/macos-14-arm64/20250901.1774)

We have some other outstanding problems, but let's see if this will fix the wheels-build, anyway.

**NOTE: please ignore the test failures for now -- see #620.**