### PR TITLE
Hyphens not underscores for generate-token parameters

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -73,8 +73,8 @@ jobs:
       uses: actions/create-github-app-token@v2
       id: generate-token
       with:
-        app_id: ${{ secrets.AUTH_APP_ID }}
-        private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+        app-id: ${{ secrets.AUTH_APP_ID }}
+        private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
     - name: "Push pull-request"
       id: cpr


### PR DESCRIPTION
Should fix the error seen here:

https://github.com/SciTools/cf-units/actions/runs/20993547617/job/60344691561#step:4:1

See also: https://github.com/SciTools/cf-units/pull/636#discussion_r2572329213