### PR TITLE
Fixing the CI through 3 changes

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -103,7 +103,7 @@ jobs:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: "cp311-* cp314-*"
         CIBW_BUILD_FRONTEND: build
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_BUILD_LINUX: yum install -y udunits2-devel
         CIBW_BEFORE_BUILD_MACOS: brew install udunits
         CIBW_BEFORE_BUILD_WINDOWS: python -m pip install delvewheel

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -78,7 +78,7 @@ jobs:
     - name: "Set MACOSX_DEPLOYMENT_TARGET"
       if: startsWith(matrix.os, 'macos')
       # Allows version targets to be set per architecture.
-      run: echo "MACOSX_DEPLOYMENT_TARGET=$([[ ${{ matrix.os }} == 'macos-latest' ]] && echo '26.0' || echo '26.0')" >> $GITHUB_ENV
+      run: echo "MACOSX_DEPLOYMENT_TARGET=$([[ ${{ matrix.os }} == 'macos-latest' ]] && echo '26.0' || echo '15.0')" >> $GITHUB_ENV
 
 
     - name: "Conda install"

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -201,6 +201,4 @@ jobs:
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
         print_hash: true

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -166,6 +166,9 @@ jobs:
     needs: [build_bdist, build_sdist]
     name: "Publish to Test PyPI"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Mandatory for PyPI Trusted Publishing OpenID Connect (OIDC)
+    environment: test-pypi
     # upload to Test PyPI for every commit on main branch
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
@@ -176,8 +179,6 @@ jobs:
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
         print_hash: true
@@ -187,6 +188,9 @@ jobs:
     needs: [build_bdist, build_sdist]
     name: "Publish to PyPI"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Mandatory for PyPI Trusted Publishing OpenID Connect (OIDC)
+    environment: pypi
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -78,7 +78,7 @@ jobs:
     - name: "Set MACOSX_DEPLOYMENT_TARGET"
       if: startsWith(matrix.os, 'macos')
       # Allows version targets to be set per architecture.
-      run: echo "MACOSX_DEPLOYMENT_TARGET=$([[ ${{ matrix.os }} == 'macos-latest' ]] && echo '15.0' || echo '15.0')" >> $GITHUB_ENV
+      run: echo "MACOSX_DEPLOYMENT_TARGET=$([[ ${{ matrix.os }} == 'macos-latest' ]] && echo '26.0' || echo '26.0')" >> $GITHUB_ENV
 
 
     - name: "Conda install"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

0f01174 - updates the manylinux version ref [python-stratify/#439](https://github.com/SciTools/python-stratify/pull/439)

3193cc9 - update the MACOSX_DEPLOYMENT_TARGET to 26 as this is the minimum required by `cf-units` dependencies

18215d4 - added the config for trusted publishing, some config also needs to be done on the pypi and test-pypi pages for this package, and so this PR is blocked until those steps are completed. See docs for more details https://github.com/pypa/gh-action-pypi-publish#usage & https://docs.pypi.org/trusted-publishers/adding-a-publisher/