### PR TITLE
Pin stable numpydoc version and fix ruff failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
         exclude: 'docs/|cf_units/_udunits2_parser/parser/.*\.py|cf_units/_udunits2_parser/_antlr4_runtime/.*\.py'
 
 -   repo: https://github.com/numpy/numpydoc
-    rev: v1.11.0rc0
+    rev: v1.10.0
     hooks:
       - id: numpydoc-validation
         types: [file, python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -374,6 +374,7 @@ ignore = [
     "PLC0414",  # Import alias does not rename original package
     "PLR0912",  # Too many branches
     "PLR0913",  # too-many-argument
+    "PLR0917",  # too-many-postional-arguments
     "PLR2004",  # magic-value-comparison
     "PT006",  # pytest-parametrize-names-wrong-type
     "PT011",  # pytest-raises-too-broad
@@ -405,6 +406,9 @@ select = [
     # rule it needs to be explicitly enabled below:
     "D212",  # Multi-line docstring summary should start at the first line
 ]
+
+[tool.ruff.lint.flake8-copyright]
+notice-rgx = "(?i)copyright.*cf-units contributors"
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# Copyright cf-units contributors
+#
+# This file is part of cf-units and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 """Setup routines to enable cf-units' Cython elements.
 
 All other setup configuration is in `pyproject.toml`.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

invalidates #686

This pins numpydoc back to the last stable version.
Allows ruff to accept the current license headers.
Ignores a ruff check about too many positional arguments.